### PR TITLE
Fixing a bug when having a NodeExtraConfigPost template present

### DIFF
--- a/files/vrouter/update_dev_net_config_files.py
+++ b/files/vrouter/update_dev_net_config_files.py
@@ -160,27 +160,6 @@ def migrate_routes(device):
     '''
     with open('/etc/sysconfig/network-scripts/route-vhost0',
               'w') as route_cfg_file:
-        for route in open('/proc/net/route', 'r').readlines():
-            if route.startswith(device):
-                route_fields = route.split()
-                destination = int(route_fields[1], 16)
-                gateway = int(route_fields[2], 16)
-                flags = int(route_fields[3], 16)
-                mask = int(route_fields[7], 16)
-                if flags & 0x2:
-                    if destination != 0:
-                        route_cfg_file.write(
-                            socket.inet_ntoa(struct.pack('I', destination)))
-                        route_cfg_file.write(
-                            '/' + str(bin(mask).count('1')) + ' ')
-                        route_cfg_file.write('via ')
-                        route_cfg_file.write(
-                            socket.inet_ntoa(struct.pack('I', gateway)) + ' ')
-                        route_cfg_file.write('dev vhost0\n')
-                    # end if detination...
-                # end if flags &...
-            # end if route.startswith...
-        # end for route...
         if os.stat('/etc/sysconfig/network-scripts/route-vhost0').st_size == 0:
             for route in open('/etc/sysconfig/network-scripts/route-'+device):
                 route_fields = route.split()


### PR DESCRIPTION
- Fixing a bug where routes would be entered twice when having post-install templates declared in the overcloud installation  
- Getting routes from /proc/net/route is not really necessary since director will push whatever configured route into /etc/sysconfig/network-scripts/route-$iface which is easyer to parse and will stay present even when the interface is down (i.e when doing a stack update)