### PR TITLE
Stable/newton: Contrail v4 support with container based deployment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spec/fixtures/
 .bundle/
 coverage/
 *.sw*
+.vscode/

--- a/lib/facter/contrail_repo_url.rb
+++ b/lib/facter/contrail_repo_url.rb
@@ -1,0 +1,15 @@
+
+Facter.add('contrail_repo_url') do
+  setcode do
+    repo_file = '/etc/yum.repos.d/contrail.repo'
+    if File.exist? repo_file
+      res = Facter::Core::Execution.exec("grep -A 5 -i 'contrail' #{repo_file} | grep 'baseurl' | head -n 1 | sed 's/\\(baseurl=\\)\\(.*\\/\\/\\)\\(.*\\)\\(\\/.*\\)/\\2\\3\\4/'")
+      if res.empty?
+        res = nil
+      end
+    else
+      res = nil
+    end
+    res
+  end
+end

--- a/manifests/analytics.pp
+++ b/manifests/analytics.pp
@@ -4,11 +4,21 @@
 #
 # === Parameters:
 #
+# [*container_name*]
+#   (optional) Container name to run,
+# [*container_url*]
+#   Mandatory for container based deployment
+#   URL for downloading container
+# [*container_tag*]
+#   (optional) Container tag to be pullled from registry,
 # [*package_name*]
 #   (optional) Package name for analytics
-#
+
 class contrail::analytics (
-  $package_name = $contrail::params::analytics_package_name,
+  $container_image          = $contrail::params::analytics_container_image,
+  $container_name           = $contrail::params::analytics_container_name,
+  $container_url            = $contrail::params::container_url,
+  $package_name             = $contrail::params::analytics_package_name,
   $alarm_gen_config,
   $analytics_api_config,
   $analytics_nodemgr_config,
@@ -22,8 +32,12 @@ class contrail::analytics (
 ) inherits contrail::params {
 
   anchor {'contrail::analytics::start': } ->
-  class {'::contrail::analytics::install': } ->
-  class {'::contrail::analytics::config': 
+  class {'::contrail::analytics::install':
+    container_image          => $container_image,
+    container_name           => $container_name,
+    container_url            => $container_url,
+  } ->
+  class {'::contrail::analytics::config':
     alarm_gen_config         => $alarm_gen_config,
     analytics_api_config     => $analytics_api_config,
     analytics_nodemgr_config => $analytics_nodemgr_config,
@@ -35,7 +49,8 @@ class contrail::analytics (
     topology_config          => $topology_config,
     vnc_api_lib_config       => $vnc_api_lib_config,
   } ~>
-  class {'::contrail::analytics::service': }
+  class {'::contrail::analytics::service':
+    container_image          => $container_image,
+  }
   anchor {'contrail::analytics::end': }
-  
 }

--- a/manifests/analytics/config.pp
+++ b/manifests/analytics/config.pp
@@ -28,6 +28,7 @@
 #   (optional) Hash of parameters for /etc/contrail/contrail-toplogy.conf
 #   Defaults to {}
 #
+
 class contrail::analytics::config (
   $alarm_gen_config         = {},
   $analytics_api_config     = {},
@@ -36,48 +37,62 @@ class contrail::analytics::config (
   $keystone_config          = {},
   $query_engine_config      = {},
   $snmp_collector_config    = {},
-  $redis_config,
+  $redis_config             = {},
   $topology_config          = {},
   $vnc_api_lib_config       = {},
-) {
-  file { '/etc/contrail/contrail-keystone-auth.conf':
-    ensure => file,
+) inherits contrail::params {
+
+  if $version < 4 {
+
+    # Package based deployment
+
+    file { '/etc/contrail/contrail-keystone-auth.conf':
+      ensure => file,
+    }
+
+    validate_hash($alarm_gen_config)
+    validate_hash($analytics_api_config)
+    validate_hash($analytics_nodemgr_config)
+    validate_hash($keystone_config)
+    validate_hash($query_engine_config)
+    validate_hash($snmp_collector_config)
+    validate_hash($topology_config)
+    validate_hash($vnc_api_lib_config)
+
+    $contrail_alarm_gen_config         = { 'path' => '/etc/contrail/contrail-alarm-gen.conf' }
+    $contrail_analytics_api_config     = { 'path' => '/etc/contrail/contrail-analytics-api.conf' }
+    $contrail_collector_config         = { 'path' => '/etc/contrail/contrail-collector.conf' }
+    $contrail_keystone_config          = { 'path' => '/etc/contrail/contrail-keystone-auth.conf' }
+    $contrail_query_engine_config      = { 'path' => '/etc/contrail/contrail-query-engine.conf' }
+    $contrail_snmp_collector_config    = { 'path' => '/etc/contrail/contrail-snmp-collector.conf' }
+    $contrail_analytics_nodemgr_config = { 'path' => '/etc/contrail/contrail-analytics-nodemgr.conf' }
+    $contrail_topology_config          = { 'path' => '/etc/contrail/contrail-topology.conf' }
+    $contrail_vnc_api_lib_config       = { 'path' => '/etc/contrail/vnc_api_lib.ini' }
+
+    file_line { 'add bind to /etc/redis.conf':
+      path => '/etc/redis.conf',
+      line => $redis_config,
+      match   => "^bind.*$",
+    }
+
+    create_ini_settings($alarm_gen_config, $contrail_alarm_gen_config)
+    create_ini_settings($analytics_api_config, $contrail_analytics_api_config)
+    create_ini_settings($analytics_nodemgr_config, $contrail_analytics_nodemgr_config)
+    create_ini_settings($collector_config, $contrail_collector_config)
+    create_ini_settings($keystone_config, $contrail_keystone_config)
+    create_ini_settings($query_engine_config, $contrail_query_engine_config)
+    create_ini_settings($snmp_collector_config, $contrail_snmp_collector_config)
+    create_ini_settings($topology_config, $contrail_topology_config)
+    create_ini_settings($vnc_api_lib_config, $contrail_vnc_api_lib_config)
+
+  } else {
+
+    # Container based deployment
+
+    # TODO: get options from upper layer via parameters, by default it reads from hiera
+    contrail::container::config { 'contrail-analytics-container-config' :
+      config_file   => 'analytics.conf',
+      template_file => 'analytics.conf.erb',
+    }
   }
-  validate_hash($alarm_gen_config)
-  validate_hash($analytics_api_config)
-  validate_hash($analytics_nodemgr_config)
-  validate_hash($collector_config)
-  validate_hash($keystone_config)
-  validate_hash($query_engine_config)
-  validate_hash($snmp_collector_config)
-  validate_hash($topology_config)
-  validate_hash($vnc_api_lib_config)
-
-
-  $contrail_alarm_gen_config         = { 'path' => '/etc/contrail/contrail-alarm-gen.conf' }
-  $contrail_analytics_api_config     = { 'path' => '/etc/contrail/contrail-analytics-api.conf' }
-  $contrail_collector_config         = { 'path' => '/etc/contrail/contrail-collector.conf' }
-  $contrail_keystone_config          = { 'path' => '/etc/contrail/contrail-keystone-auth.conf' }
-  $contrail_query_engine_config      = { 'path' => '/etc/contrail/contrail-query-engine.conf' }
-  $contrail_snmp_collector_config    = { 'path' => '/etc/contrail/contrail-snmp-collector.conf' }
-  $contrail_analytics_nodemgr_config = { 'path' => '/etc/contrail/contrail-analytics-nodemgr.conf' }
-  $contrail_topology_config          = { 'path' => '/etc/contrail/contrail-topology.conf' }
-  $contrail_vnc_api_lib_config       = { 'path' => '/etc/contrail/vnc_api_lib.ini' }
-
-  file_line { 'add bind to /etc/redis.conf':
-    path => '/etc/redis.conf',
-    line => $redis_config,
-    match   => "^bind.*$",
-  }
-
-  create_ini_settings($alarm_gen_config, $contrail_alarm_gen_config)
-  create_ini_settings($analytics_api_config, $contrail_analytics_api_config)
-  create_ini_settings($analytics_nodemgr_config, $contrail_analytics_nodemgr_config)
-  create_ini_settings($collector_config, $contrail_collector_config)
-  create_ini_settings($keystone_config, $contrail_keystone_config)
-  create_ini_settings($query_engine_config, $contrail_query_engine_config)
-  create_ini_settings($snmp_collector_config, $contrail_snmp_collector_config)
-  create_ini_settings($topology_config, $contrail_topology_config)
-  create_ini_settings($vnc_api_lib_config, $contrail_vnc_api_lib_config)
-
 }

--- a/manifests/analytics/install.pp
+++ b/manifests/analytics/install.pp
@@ -4,23 +4,34 @@
 #
 # === Parameters:
 #
-# [*package_name*]
-#   (optional) Package name for analytics
+# [*container_name*]
+#   (optional) Container name to load,
 #
+# [*container_url*]
+#   Mandatory for container based deployment
+#   URL for downloading container
+#
+
 class contrail::analytics::install (
-) {
+  $container_image          = undef,
+  $container_name           = undef,
+  $container_url            = undef,
+) inherits contrail::params {
 
-  package { 'wget' :
-    ensure => latest,
+  if $version < 4 {
+    package { 'python-redis' :
+      ensure => absent,
+    } ->
+    package { 'python-gevent' :
+      ensure => latest,
+    } ->
+    package { 'contrail-openstack-analytics' :
+      ensure => latest,
+    }
+  } else {
+    contrail::container::install { $container_name :
+      container_image => $container_image,
+      container_url   => $container_url,
+    }
   }
-  package { 'python-redis' :
-    ensure => absent,
-  } ->
-  package { 'python-gevent' :
-    ensure => latest,
-  } ->
-  package { 'contrail-openstack-analytics' :
-    ensure => latest,
-  }
-
 }

--- a/manifests/analytics/provision_analytics.pp
+++ b/manifests/analytics/provision_analytics.pp
@@ -36,6 +36,7 @@
 #   (optional) Operation to run (add|del)
 #   Defaults to 'add'
 #
+
 class contrail::analytics::provision_analytics (
   $api_address                = '127.0.0.1',
   $api_port                   = 8082,
@@ -46,29 +47,39 @@ class contrail::analytics::provision_analytics (
   $keystone_admin_tenant_name = 'admin',
   $oper                       = 'add',
   $openstack_vip              = '127.0.0.1',
-) {
+) inherits contrail::params {
 
-  #exec { "analytics deploy wait for keystone become available" :
-  #  path => '/usr/bin',
-  #  command => "/usr/bin/wget --spider --tries 150 --waitretry=2 --retry-connrefused http://${openstack_vip}:35357",
-  #} ->
-  #exec { "analytics deploy wait for contrail config become available" :
-  #  path => '/usr/bin',
-  #  command => "/usr/bin/wget --spider --tries 150 --waitretry=2 --retry-connrefused http://${api_address}:8082",
-  #} ->
-  exec { "provision_analytics_node.py ${control_node_name}" :
-    path => '/usr/bin',
-    command => "python /opt/contrail/utils/provision_analytics_node.py \
-                 --host_name ${::fqdn} \
-                 --host_ip ${analytics_node_address} \
-                 --api_server_ip ${api_address} \
-                 --api_server_port ${api_port} \
-                 --admin_user ${keystone_admin_user} \
-                 --admin_password ${keystone_admin_password} \
-                 --admin_tenant ${keystone_admin_tenant_name} \
-                 --openstack_ip ${openstack_vip} \
-                 --oper ${oper}",
-    tries => 100,
-    try_sleep => 3, 
+  if $version < 4 {
+
+    # Package based deployment
+
+    #exec { "analytics deploy wait for keystone become available" :
+    #  path => '/usr/bin',
+    #  command => "/usr/bin/wget --spider --tries 150 --waitretry=2 --retry-connrefused http://${openstack_vip}:35357",
+    #} ->
+    #exec { "analytics deploy wait for contrail config become available" :
+    #  path => '/usr/bin',
+    #  command => "/usr/bin/wget --spider --tries 150 --waitretry=2 --retry-connrefused http://${api_address}:8082",
+    #} ->
+    exec { "provision_analytics_node.py ${control_node_name}" :
+      path => '/usr/bin',
+      command => "python /opt/contrail/utils/provision_analytics_node.py \
+                   --host_name ${::fqdn} \
+                   --host_ip ${analytics_node_address} \
+                   --api_server_ip ${api_address} \
+                   --api_server_port ${api_port} \
+                   --admin_user ${keystone_admin_user} \
+                   --admin_password ${keystone_admin_password} \
+                   --admin_tenant ${keystone_admin_tenant_name} \
+                   --openstack_ip ${openstack_vip} \
+                   --oper ${oper}",
+      tries => 100,
+      try_sleep => 3,
+    }
+  } else {
+
+    # Container based deployment
+
+    notify { 'Skip analytics provisioning step in container based deployment': }
   }
 }

--- a/manifests/analytics/service.pp
+++ b/manifests/analytics/service.pp
@@ -2,15 +2,35 @@
 #
 # Manage the analytics service
 #
-class contrail::analytics::service {
+# === Parameters:
+#
+# [*container_image*]
+#   (optional) Mandatory in case of container based deployment
+#   Container image to be run
+#
 
-  service {'redis' :
-    ensure => running,
-    enable => true,
-  } ->
-  service {'supervisor-analytics' :
-    ensure => running,
-    enable => true,
+class contrail::analytics::service(
+  $container_image      = undef,
+) inherits contrail::params {
+
+  if $version < 4 {
+
+    # Package based deployment
+
+    service {'redis' :
+      ensure => running,
+      enable => true,
+    } ->
+    service {'supervisor-analytics' :
+      ensure => running,
+      enable => true,
+    }
+  } else {
+
+    # Container based deployment
+
+    contrail::container::run { 'contrail-analytics-container' :
+      container_image => $container_image,
+    }
   }
-
 }

--- a/manifests/analyticsdatabase.pp
+++ b/manifests/analyticsdatabase.pp
@@ -4,25 +4,39 @@
 #
 # === Parameters:
 #
+# [*container_name*]
+#   (optional) Container name to run,
+# [*container_url*]
+#   URL for downloading container
+# [*container_tag*]
+#   (optional) Container tag to be pullled from registry,
 # [*package_name*]
 #   (optional) Package name for database
 #
 class contrail::analyticsdatabase (
-  $package_name = $contrail::params::database_package_name,
-  $analyticsdatabase_params = $analyticsdatabase_params,
+  $analyticsdatabase_params = {},
+  $container_image          = $contrail::params::analyticsdb_container_image,
+  $container_name           = $contrail::params::analyticsdb_container_name,
+  $container_url            = $contrail::params::container_url,
+  $package_name             = $contrail::params::database_package_name,
 ) inherits contrail::params {
 
   anchor {'contrail::analyticsdatabase::start': } ->
-  class {'::contrail::analyticsdatabase::install': } ->
-  class {'::contrail::analyticsdatabase::config': 
-    database_nodemgr_config => $analyticsdatabase_params['database_nodemgr_config'],
-    cassandra_servers       => $analyticsdatabase_params['cassandra_servers'],
+  class {'::contrail::analyticsdatabase::install':
+    container_image          => $container_image,
+    container_name           => $container_name,
+    container_url            => $container_url,
+  } ->
+  class {'::contrail::analyticsdatabase::config':
     cassandra_ip            => $analyticsdatabase_params['host_ip'],
+    cassandra_servers       => $analyticsdatabase_params['cassandra_servers'],
+    database_nodemgr_config => $analyticsdatabase_params['database_nodemgr_config'],
     kafka_hostnames         => $analyticsdatabase_params['kafka_hostnames'],
     vnc_api_lib_config      => $analyticsdatabase_params['vnc_api_lib_config'],
     zookeeper_server_ips    => $analyticsdatabase_params['zookeeper_server_ips'],
   } ~>
-  class {'::contrail::analyticsdatabase::service': }
+  class {'::contrail::analyticsdatabase::service':
+    container_image          => $container_image,
+  }
   anchor {'contrail::analyticsdatabase::end': }
-  
 }

--- a/manifests/analyticsdatabase/config.pp
+++ b/manifests/analyticsdatabase/config.pp
@@ -8,9 +8,10 @@
 #   (optional) Hash of parameters for /etc/contrail/contrail-database-nodemgr.conf
 #   Defaults to {}
 #
+
 class contrail::analyticsdatabase::config (
   $database_nodemgr_config = {},
-  $cassandra_servers       = "",
+  $cassandra_servers       = [],
   $cassandra_ip            = $::ipaddress,
   $storage_port            = '7000',
   $ssl_storage_port        = '7001',
@@ -18,146 +19,162 @@ class contrail::analyticsdatabase::config (
   $client_port_thrift      = '9160',
   $kafka_hostnames         = hiera('contrail_analytics_database_short_node_names', ''),
   $vnc_api_lib_config      = {},
-  $zookeeper_server_ips    = hiera('contrail_database_node_ips'),
-) {
-  $zk_server_ip_2181 = join([join($zookeeper_server_ips, ':2181,'),":2181"],'')
-  validate_hash($database_nodemgr_config)
-  validate_hash($vnc_api_lib_config)
-  $contrail_database_nodemgr_config = { 'path' => '/etc/contrail/contrail-database-nodemgr.conf' }
-  $contrail_vnc_api_lib_config = { 'path' => '/etc/contrail/vnc_api_lib.ini' }
-  $cassandra_seeds_list = $cassandra_servers[0,2]
-  if $cassandra_seeds_list.size > 1 {
-    $cassandra_seeds = join($cassandra_seeds_list,",")
-    $kafka_replication = '2'
-  } else {
-    $cassandra_seeds = $cassandra_seeds_list[0]
-    $kafka_replication = '1'
-  }
+  $zookeeper_server_ips    = hiera('contrail_database_node_ips', ''),
+) inherits contrail::params {
 
-  create_ini_settings($database_nodemgr_config, $contrail_database_nodemgr_config)
-  create_ini_settings($vnc_api_lib_config, $contrail_vnc_api_lib_config)
-  validate_ipv4_address($cassandra_ip)
+  if $version < 4 {
 
-  file { ['/var/lib/cassandra', ]:
-    ensure => 'directory',
-    owner  => 'cassandra',
-    group  => 'cassandra',
-    mode   => '0755',
-  } ->
-  class {'::cassandra':
-#    service_ensure => stopped,
-#    service_enable => false,
-    settings => {
-      'cluster_name'          => 'ContrailAnalytics',
-      'listen_address'        => $cassandra_ip,
-      'storage_port'          => $storage_port,
-      'ssl_storage_port'      => $ssl_storage_port,
-      'native_transport_port' => $client_port,
-      'rpc_port'              => $client_port_thrift,
-      'commitlog_directory'         => '/var/lib/cassandra/commitlog',
-      'commitlog_sync'              => 'periodic',
-      'commitlog_sync_period_in_ms' => 10000,
-      'partitioner'                 => 'org.apache.cassandra.dht.Murmur3Partitioner',
-      'endpoint_snitch'             => 'GossipingPropertyFileSnitch',
-      'data_file_directories'       => ['/var/lib/cassandra/data'],
-      'saved_caches_directory'      => '/var/lib/cassandra/saved_caches',
-      'seed_provider'               => [
-        {
-          'class_name' => 'org.apache.cassandra.locator.SimpleSeedProvider',
-          'parameters' => [
-            {
-              'seeds' => $cassandra_seeds,
-            },
-          ],
-        },
-      ],
-      'start_native_transport'      => true,
+    # Package based deployment
+
+    validate_hash($database_nodemgr_config)
+    validate_hash($vnc_api_lib_config)
+    $zk_server_ip_2181 = join([join($zookeeper_server_ips, ':2181,'),":2181"],'')
+    $contrail_database_nodemgr_config = { 'path' => '/etc/contrail/contrail-database-nodemgr.conf' }
+    $contrail_vnc_api_lib_config = { 'path' => '/etc/contrail/vnc_api_lib.ini' }
+    $cassandra_seeds_list = $cassandra_servers[0,2]
+    if $cassandra_seeds_list.size > 1 {
+      $cassandra_seeds = join($cassandra_seeds_list,",")
+      $kafka_replication = '2'
+    } else {
+      $cassandra_seeds = $cassandra_seeds_list[0]
+      $kafka_replication = '1'
     }
-  } 
-  file { '/usr/share/kafka/config/server.properties':
-    ensure => present,
-  }->
-  file_line { 'add zookeeper servers to kafka config':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "zookeeper.connect=${zk_server_ip_2181}",
-    match   => "^zookeeper.connect=.*$",
-  }
-  $kafka_broker_id = extract_id($kafka_hostnames, $::hostname)
-  file_line { 'set kafka broker id':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "broker.id=${kafka_broker_id}",
-    match   => "^broker.id=.*$",
-  }
-  file_line { 'set kafka advertised.host.name':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "advertised.host.name=${::ipaddress}",
-  }
-  file_line { 'set kafka num.network.threads=3':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "num.network.threads=3",
-  }
-  file_line { 'set kafka num.io.threads=8':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "num.io.threads=8",
-  }
-  file_line { 'set kafka socket.send.buffer.bytes=102400':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "socket.send.buffer.bytes=102400",
-  }
-  file_line { 'set kafka socket.receive.buffer.bytes=102400':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "socket.receive.buffer.bytes=102400",
-  }
-  file_line { 'set kafka socket.request.max.bytes=104857600':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "socket.request.max.bytes=104857600",
-  }
-  file_line { 'set kafka num.partitions=1':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "num.partitions=1",
-  }
-  file_line { 'set kafka num.recovery.threads.per.data.dir=1':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "num.recovery.threads.per.data.dir=1",
-  }
-  file_line { 'set kafka log.retention.hours=24':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "log.retention.hours=24",
-  }
-  file_line { 'set kafka log.retention.bytes=268435456':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "log.retention.bytes=268435456",
-  }
-  file_line { 'set kafka log.segment.bytes=268435456':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "log.segment.bytes=268435456",
-  }
-  file_line { 'set kafka log.retention.check.interval.ms=300000':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "log.retention.check.interval.ms=300000",
-  }
-  file_line { 'set kafka zookeeper.connection.timeout.ms=6000':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "zookeeper.connection.timeout.ms=6000",
-  }
-  file_line { 'set kafka log.cleanup.policy=delete':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "log.cleanup.policy=delete",
-  }
-  file_line { 'set kafka delete.topic.enable=true':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "delete.topic.enable=true",
-  }
-  file_line { 'set kafka log.cleaner.threads=2':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "log.cleaner.threads=2",
-  }
-  file_line { 'set kafka log.cleaner.dedupe.buffer.size=250000000':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "log.cleaner.dedupe.buffer.size=250000000",
-  }
-  file_line { 'set kafka default.replication.factor=':
-    path => '/usr/share/kafka/config/server.properties',
-    line => "default.replication.factor=${kafka_replication}",
+
+    create_ini_settings($database_nodemgr_config, $contrail_database_nodemgr_config)
+    create_ini_settings($vnc_api_lib_config, $contrail_vnc_api_lib_config)
+    validate_ipv4_address($cassandra_ip)
+
+    file { ['/var/lib/cassandra', ]:
+      ensure => 'directory',
+      owner  => 'cassandra',
+      group  => 'cassandra',
+      mode   => '0755',
+    } ->
+    class {'::cassandra':
+#     service_ensure => stopped,
+#     service_enable => false,
+      settings => {
+        'cluster_name'          => 'ContrailAnalytics',
+        'listen_address'        => $cassandra_ip,
+        'storage_port'          => $storage_port,
+        'ssl_storage_port'      => $ssl_storage_port,
+        'native_transport_port' => $client_port,
+        'rpc_port'              => $client_port_thrift,
+        'commitlog_directory'         => '/var/lib/cassandra/commitlog',
+        'commitlog_sync'              => 'periodic',
+        'commitlog_sync_period_in_ms' => 10000,
+        'partitioner'                 => 'org.apache.cassandra.dht.Murmur3Partitioner',
+        'endpoint_snitch'             => 'GossipingPropertyFileSnitch',
+        'data_file_directories'       => ['/var/lib/cassandra/data'],
+        'saved_caches_directory'      => '/var/lib/cassandra/saved_caches',
+        'seed_provider'               => [
+          {
+            'class_name' => 'org.apache.cassandra.locator.SimpleSeedProvider',
+            'parameters' => [
+              {
+                'seeds' => $cassandra_seeds,
+              },
+            ],
+          },
+        ],
+        'start_native_transport'      => true,
+      }
+    }
+    file { '/usr/share/kafka/config/server.properties':
+      ensure => present,
+    }->
+    file_line { 'add zookeeper servers to kafka config':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "zookeeper.connect=${zk_server_ip_2181}",
+      match   => "^zookeeper.connect=.*$",
+    }
+    $kafka_broker_id = extract_id($kafka_hostnames, $::hostname)
+    file_line { 'set kafka broker id':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "broker.id=${kafka_broker_id}",
+      match   => "^broker.id=.*$",
+    }
+    file_line { 'set kafka advertised.host.name':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "advertised.host.name=${::ipaddress}",
+    }
+    file_line { 'set kafka num.network.threads=3':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "num.network.threads=3",
+    }
+    file_line { 'set kafka num.io.threads=8':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "num.io.threads=8",
+    }
+    file_line { 'set kafka socket.send.buffer.bytes=102400':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "socket.send.buffer.bytes=102400",
+    }
+    file_line { 'set kafka socket.receive.buffer.bytes=102400':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "socket.receive.buffer.bytes=102400",
+    }
+    file_line { 'set kafka socket.request.max.bytes=104857600':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "socket.request.max.bytes=104857600",
+    }
+    file_line { 'set kafka num.partitions=1':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "num.partitions=1",
+    }
+    file_line { 'set kafka num.recovery.threads.per.data.dir=1':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "num.recovery.threads.per.data.dir=1",
+    }
+    file_line { 'set kafka log.retention.hours=24':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "log.retention.hours=24",
+    }
+    file_line { 'set kafka log.retention.bytes=268435456':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "log.retention.bytes=268435456",
+    }
+    file_line { 'set kafka log.segment.bytes=268435456':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "log.segment.bytes=268435456",
+    }
+    file_line { 'set kafka log.retention.check.interval.ms=300000':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "log.retention.check.interval.ms=300000",
+    }
+    file_line { 'set kafka zookeeper.connection.timeout.ms=6000':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "zookeeper.connection.timeout.ms=6000",
+    }
+    file_line { 'set kafka log.cleanup.policy=delete':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "log.cleanup.policy=delete",
+    }
+    file_line { 'set kafka delete.topic.enable=true':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "delete.topic.enable=true",
+    }
+    file_line { 'set kafka log.cleaner.threads=2':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "log.cleaner.threads=2",
+    }
+    file_line { 'set kafka log.cleaner.dedupe.buffer.size=250000000':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "log.cleaner.dedupe.buffer.size=250000000",
+    }
+    file_line { 'set kafka default.replication.factor=':
+      path => '/usr/share/kafka/config/server.properties',
+      line => "default.replication.factor=${kafka_replication}",
+    }
+
+  } else {
+
+    # Container based deployment
+
+    # TODO: get options from upper layer via parameters, by default it reads from hiera
+    contrail::container::config { 'contrail-analyticsdb-container-config' :
+      config_file   => 'analyticsdb.conf',
+      template_file => 'analyticsdb.conf.erb',
+    }
   }
 }

--- a/manifests/analyticsdatabase/install.pp
+++ b/manifests/analyticsdatabase/install.pp
@@ -4,27 +4,42 @@
 #
 # === Parameters:
 #
-# [*package_name*]
-#   (optional) Package name for database
+# === Parameters:
 #
+# [*container_name*]
+#   (optional) Container name to load,
+#
+# [*container_url*]
+#   URL for downloading container
+#
+
 class contrail::analyticsdatabase::install (
-) {
+  $container_image          = undef,
+  $container_name           = undef,
+  $container_url            = undef,
+) inherits contrail::params {
 
-  package { 'wget' :
-    ensure => latest,
-  } ->
-  package { 'java-1.8.0-openjdk' :
-    ensure => latest,
-  } ->
-  package { 'contrail-openstack-database' :
-    ensure => latest,
+  if $version < 4 {
+    package { 'wget' :
+      ensure => latest,
+    } ->
+    package { 'java-1.8.0-openjdk' :
+      ensure => latest,
+    } ->
+    package { 'contrail-openstack-database' :
+      ensure => latest,
+    }
+#   } ->
+#   exec { 'stop contrail-database service':
+#        command => '/bin/systemctl stop contrail-database',
+#   } ->
+#   exec { 'rm -rf /var/lib/cassandra/data/*' :
+#      path => '/bin',
+#   }
+  } else {
+     contrail::container::install { $container_name :
+      container_image => $container_image,
+      container_url   => $container_url,
+    }
   }
-#  } ->
-#  exec { 'stop contrail-database service':
-#      command => '/bin/systemctl stop contrail-database',
-#  } ->
-#  exec { 'rm -rf /var/lib/cassandra/data/*' :
-#    path => '/bin',
-#  }
-
 }

--- a/manifests/analyticsdatabase/service.pp
+++ b/manifests/analyticsdatabase/service.pp
@@ -4,18 +4,33 @@
 #
 # === Parameters:
 #
-# [*package_name*]
-#   (optional) Package name for database
+# [*container_image*]
+#   (optional) Mandatory in case of container based deployment
+#   Container image to be run
 #
-class contrail::analyticsdatabase::service {
 
-  service {'contrail-database' :
-    ensure => running,
-    enable => true,
-  }
-  service {'supervisor-database' :
-    ensure => running,
-    enable => true,
-  }
+class contrail::analyticsdatabase::service(
+  $container_image      = undef,
+) inherits contrail::params {
 
+  if $version < 4 {
+
+    # Package based deployment
+
+    service {'contrail-database' :
+      ensure => running,
+      enable => true,
+    }
+    service {'supervisor-database' :
+      ensure => running,
+      enable => true,
+    }
+  } else {
+
+    # Container based deployment
+
+    contrail::container::run { 'contrail-analyticsdb-container' :
+      container_image => $container_image,
+    }
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,11 +4,22 @@
 #
 # === Parameters:
 #
+# [*container_name*]
+#   (optional) Container name to run,
+# [*container_url*]
+#   Mandatory for container based deployment
+#   URL for downloading container
+# [*container_tag*]
+#   (optional) Container tag to be pullled from registry,
+#   'latest' will be used if it is unset
 # [*package_name*]
 #   (optional) Package name for config
-#
+
 class contrail::config (
-  $package_name = $contrail::params::config_package_name,
+  $container_image          = $contrail::params::controller_container_image,
+  $container_name           = $contrail::params::controller_container_name,
+  $container_url            = $contrail::params::container_url,
+  $package_name             = $contrail::params::config_package_name,
   $api_config,
   $basicauthusers_property,
   $config_nodemgr_config,
@@ -21,8 +32,12 @@ class contrail::config (
 ) inherits contrail::params  {
 
   anchor {'contrail::config::start': } ->
-  class {'::contrail::config::install': } ->
-  class {'::contrail::config::config': 
+  class {'::contrail::config::install':
+    container_image          => $container_image,
+    container_name           => $container_name,
+    container_url            => $container_url,
+   } ->
+  class {'::contrail::config::config':
     api_config              => $api_config,
     basicauthusers_property => $basicauthusers_property,
     config_nodemgr_config   => $config_nodemgr_config,
@@ -33,8 +48,9 @@ class contrail::config (
     svc_monitor_config      => $svc_monitor_config,
     vnc_api_lib_config      => $vnc_api_lib_config,
   } ~>
-  class {'::contrail::config::service': }
+  class {'::contrail::config::service':
+    container_image          => $container_image,
+  }
   anchor {'contrail::config::end': }
-  
 }
 

--- a/manifests/config/config.pp
+++ b/manifests/config/config.pp
@@ -36,6 +36,7 @@
 #   (optional) List of pairs of ifmap users. Example: user1:password1
 #   Defaults to []
 #
+
 class contrail::config::config (
   $alarm_gen_config        = {},
   $api_config              = {},
@@ -47,51 +48,64 @@ class contrail::config::config (
   $schema_config           = {},
   $svc_monitor_config      = {},
   $vnc_api_lib_config      = {},
-) {
+) inherits contrail::params {
 
-  file { '/etc/contrail/contrail-keystone-auth.conf':
-    ensure => file,
+  if $version < 4 {
+
+    # Package based deployment
+    file { '/etc/contrail/contrail-keystone-auth.conf':
+      ensure => file,
+    }
+
+    validate_hash($api_config)
+    validate_hash($alarm_gen_config)
+    validate_hash($config_nodemgr_config)
+    validate_hash($device_manager_config)
+    validate_hash($discovery_config)
+    validate_hash($keystone_config)
+    validate_hash($schema_config)
+    validate_hash($svc_monitor_config)
+    validate_hash($vnc_api_lib_config)
+
+    validate_array($basicauthusers_property)
+
+    $contrail_alarm_gen_config = { 'path' => '/etc/contrail/contrail-alarm-gen.conf' }
+    $contrail_config_nodemgr_config = { 'path' => '/etc/contrail/contrail-config-nodemgr.conf' }
+    $contrail_container_api_config = { 'path' => '/etc/contrailctl/controller.conf' }
+    $contrail_device_manager_config = { 'path' => '/etc/contrail/contrail-device-manager.conf' }
+    $contrail_discovery_config = { 'path' => '/etc/contrail/contrail-discovery.conf' }
+    $contrail_keystone_config = { 'path' => '/etc/contrail/contrail-keystone-auth.conf' }
+    $contrail_schema_config = { 'path' => '/etc/contrail/contrail-schema.conf' }
+    $contrail_svc_monitor_config = { 'path' => '/etc/contrail/contrail-svc-monitor.conf' }
+    $contrail_vnc_api_lib_config = { 'path' => '/etc/contrail/vnc_api_lib.ini' }
+
+    create_ini_settings($api_config, $contrail_api_config)
+    create_ini_settings($alarm_gen_config, $contrail_alarm_gen_config)
+    create_ini_settings($config_nodemgr_config, $contrail_config_nodemgr_config)
+    create_ini_settings($device_manager_config, $contrail_device_manager_config)
+    create_ini_settings($discovery_config, $contrail_discovery_config)
+    create_ini_settings($keystone_config, $contrail_keystone_config)
+    create_ini_settings($schema_config, $contrail_schema_config)
+    create_ini_settings($svc_monitor_config, $contrail_svc_monitor_config)
+    create_ini_settings($vnc_api_lib_config, $contrail_vnc_api_lib_config)
+
+    file { '/etc/ifmap-server/basicauthusers.properties' :
+      ensure  => file,
+      content => template('contrail/config/basicauthusers.properties.erb'),
+    }
+
+    file {'/etc/ifmap-server/log4j.properties' :
+      ensure  => file,
+      content => template('contrail/config/log4j.properties.erb'),
+    }
+  } else {
+
+    # Container based deployment
+
+    # TODO: get options from upper layer via parameters, by default it reads from hiera
+    contrail::container::config { 'contrail-controller-container-config' :
+      config_file   => 'controller.conf',
+      template_file => 'controller.conf.erb',
+    }
   }
-  validate_hash($api_config)
-  validate_hash($alarm_gen_config)
-  validate_hash($config_nodemgr_config)
-  validate_hash($device_manager_config)
-  validate_hash($discovery_config)
-  validate_hash($keystone_config)
-  validate_hash($schema_config)
-  validate_hash($svc_monitor_config)
-  validate_hash($vnc_api_lib_config)
-
-  validate_array($basicauthusers_property)
-
-  $contrail_api_config = { 'path' => '/etc/contrail/contrail-api.conf' }
-  $contrail_alarm_gen_config = { 'path' => '/etc/contrail/contrail-alarm-gen.conf' }
-  $contrail_config_nodemgr_config = { 'path' => '/etc/contrail/contrail-config-nodemgr.conf' }
-  $contrail_device_manager_config = { 'path' => '/etc/contrail/contrail-device-manager.conf' }
-  $contrail_discovery_config = { 'path' => '/etc/contrail/contrail-discovery.conf' }
-  $contrail_keystone_config = { 'path' => '/etc/contrail/contrail-keystone-auth.conf' }
-  $contrail_schema_config = { 'path' => '/etc/contrail/contrail-schema.conf' }
-  $contrail_svc_monitor_config = { 'path' => '/etc/contrail/contrail-svc-monitor.conf' }
-  $contrail_vnc_api_lib_config = { 'path' => '/etc/contrail/vnc_api_lib.ini' }
-
-  create_ini_settings($api_config, $contrail_api_config)
-  create_ini_settings($alarm_gen_config, $contrail_alarm_gen_config)
-  create_ini_settings($config_nodemgr_config, $contrail_config_nodemgr_config)
-  create_ini_settings($device_manager_config, $contrail_device_manager_config)
-  create_ini_settings($discovery_config, $contrail_discovery_config)
-  create_ini_settings($keystone_config, $contrail_keystone_config)
-  create_ini_settings($schema_config, $contrail_schema_config)
-  create_ini_settings($svc_monitor_config, $contrail_svc_monitor_config)
-  create_ini_settings($vnc_api_lib_config, $contrail_vnc_api_lib_config)
-
-  file { '/etc/ifmap-server/basicauthusers.properties' :
-    ensure  => file,
-    content => template('contrail/config/basicauthusers.properties.erb'),
-  }
-
-  file {'/etc/ifmap-server/log4j.properties' :
-    ensure  => file,
-    content => template('contrail/config/log4j.properties.erb'),
-  }
-
 }

--- a/manifests/config/install.pp
+++ b/manifests/config/install.pp
@@ -4,19 +4,34 @@
 #
 # === Parameters:
 #
-# [*package_name*]
-#   (optional) Package name for config
+# [*container_name*]
+#   (optional) Container name to load,
 #
-class contrail::config::install (
-) {
-  package { 'wget' :
-    ensure => latest,
-  }
-  package { 'python-gevent' :
-    ensure => latest,
-  } ->
-  package { 'contrail-openstack-config' :
-    ensure => latest,
-  }
+# [*container_url*]
+#   Mandatory for container based deployment
+#   URL for downloading container
+#
 
+class contrail::config::install (
+  $container_image          = undef,
+  $container_name           = undef,
+  $container_url            = undef,
+) inherits contrail::params {
+
+  if $version < 4 {
+    package { 'wget' :
+      ensure => latest,
+    }
+    package { 'python-gevent' :
+      ensure => latest,
+    } ->
+    package { 'contrail-openstack-config' :
+      ensure => latest,
+    }
+  } else {
+     contrail::container::install { $container_name :
+      container_image => $container_image,
+      container_url   => $container_url,
+    }
+  }
 }

--- a/manifests/config/provision_config.pp
+++ b/manifests/config/provision_config.pp
@@ -36,6 +36,7 @@
 #   (optional) Operation to run (add|del)
 #   Defaults to 'add'
 #
+
 class contrail::config::provision_config (
   $api_address                = '127.0.0.1',
   $api_port                   = 8082,
@@ -46,20 +47,28 @@ class contrail::config::provision_config (
   $keystone_admin_tenant_name = 'admin',
   $oper                       = 'add',
   $openstack_vip              = '127.0.0.1',
-) {
-  exec { "provision_config_node.py ${config_node_name}" :
-    path => '/usr/bin',
-    command => "python /opt/contrail/utils/provision_config_node.py \
-                 --host_name ${::fqdn} \
-                 --host_ip ${config_node_address} \
-                 --api_server_ip ${api_address} \
-                 --api_server_port ${api_port} \
-                 --admin_user ${keystone_admin_user} \
-                 --admin_password ${keystone_admin_password} \
-                 --admin_tenant ${keystone_admin_tenant_name} \
-                 --openstack_ip ${openstack_vip} \
-                 --oper ${oper}",
-    tries => 100,
-    try_sleep => 3,
+) inherits contrail::params {
+
+  if $version < 4 {
+    exec { "provision_config_node.py ${config_node_name}" :
+      path => '/usr/bin',
+      command => "python /opt/contrail/utils/provision_config_node.py \
+                  --host_name ${::fqdn} \
+                  --host_ip ${config_node_address} \
+                  --api_server_ip ${api_address} \
+                  --api_server_port ${api_port} \
+                  --admin_user ${keystone_admin_user} \
+                  --admin_password ${keystone_admin_password} \
+                  --admin_tenant ${keystone_admin_tenant_name} \
+                  --openstack_ip ${openstack_vip} \
+                  --oper ${oper}",
+      tries => 100,
+      try_sleep => 3,
+    }
+  } else {
+
+    # Container based deployment
+
+    notify { 'Skip Contrail-Controller config provisioning step in container based deployment': }
   }
 }

--- a/manifests/config/provision_linklocal.pp
+++ b/manifests/config/provision_linklocal.pp
@@ -52,6 +52,7 @@
 #   (optional) Operation to run (add|del)
 #   Defaults to 'add'
 #
+
 class contrail::config::provision_linklocal (
   $api_address                = '127.0.0.1',
   $api_port                   = 8082,
@@ -64,28 +65,35 @@ class contrail::config::provision_linklocal (
   $linklocal_service_ip       = '169.254.169.254',
   $linklocal_service_port     = 80,
   $oper                       = 'add',
-) {
+) inherits contrail::params {
 
-  #exec { "link local deploy wait for contrail config become available" :
-  #  path => '/usr/bin',
-  #  command => "/usr/bin/wget --spider --tries 150 --waitretry=2 --retry-connrefused http://${api_address}:8082",
-  #} ->
-  exec { "provision_linklocal.py ${api_address}" :
-    path => '/usr/bin',
-    command => "python /opt/contrail/utils/provision_linklocal.py \
-                 --api_server_ip ${api_address} \
-                 --api_server_port ${api_port} \
-                 --linklocal_service_name ${linklocal_service_name} \
-                 --linklocal_service_ip ${linklocal_service_ip} \
-                 --linklocal_service_port ${linklocal_service_port} \
-                 --ipfabric_service_ip ${ipfabric_service_ip} \
-                 --ipfabric_service_port ${ipfabric_service_port} \
-                 --admin_user ${keystone_admin_user} \
-                 --admin_password ${keystone_admin_password} \
-                 --admin_tenant ${keystone_admin_tenant_name} \
-                 --oper ${oper}",
-    tries => 100,
-    try_sleep => 3,
+  if $version < 4 {
+
+    #exec { "link local deploy wait for contrail config become available" :
+    #  path => '/usr/bin',
+    #  command => "/usr/bin/wget --spider --tries 150 --waitretry=2 --retry-connrefused http://${api_address}:8082",
+    #} ->
+    exec { "provision_linklocal.py ${api_address}" :
+      path => '/usr/bin',
+      command => "python /opt/contrail/utils/provision_linklocal.py \
+                  --api_server_ip ${api_address} \
+                  --api_server_port ${api_port} \
+                  --linklocal_service_name ${linklocal_service_name} \
+                  --linklocal_service_ip ${linklocal_service_ip} \
+                  --linklocal_service_port ${linklocal_service_port} \
+                  --ipfabric_service_ip ${ipfabric_service_ip} \
+                  --ipfabric_service_port ${ipfabric_service_port} \
+                  --admin_user ${keystone_admin_user} \
+                  --admin_password ${keystone_admin_password} \
+                  --admin_tenant ${keystone_admin_tenant_name} \
+                  --oper ${oper}",
+      tries => 100,
+      try_sleep => 3,
+    }
+  } else {
+
+    # Container based deployment
+
+    notify { 'Skip Contrail-Controller linklocal provisioning step in container based deployment': }
   }
-
 }

--- a/manifests/config/service.pp
+++ b/manifests/config/service.pp
@@ -2,12 +2,31 @@
 #
 # Manage the config service
 #
-class contrail::config::service {
+# === Parameters:
+#
+# [*container_image*]
+#   (optional) Mandatory in case of container based deployment
+#   Container image to be run
+#
 
-  service {'supervisor-config' :
-    ensure => running,
-    enable => true,
+class contrail::config::service(
+  $container_image      = undef,
+) inherits contrail::params {
+
+  if $version < 4 {
+
+    # Package based deployment
+    service {'supervisor-config' :
+      ensure => running,
+      enable => true,
+    }
+  } else {
+
+    # Container based deployment
+
+    contrail::container::run { 'contrail-controller-container' :
+      container_image => $container_image,
+    }
   }
-
 }
 

--- a/manifests/container/config.pp
+++ b/manifests/container/config.pp
@@ -1,0 +1,71 @@
+
+# TODO: ssl_enabled - probably use another parameter, e.g. insecure
+# TODO: to check controller_virtual_ip, glance_api_ip, neutron_metadata_ip
+# TODO: pass from upper layer: configdb_cassandra_user, configdb_cassandra_password
+# TODO: pass from upper layer: analyticsdb_cassandra_user, analyticsdb_cassandra_password
+
+define contrail::container::config (
+  $config_file,
+  $config_file_dir                = '/etc/contrailctl',
+  $template_file,
+  $template_file_dir              = 'contrail/contrailctl',
+
+  $aaa_mode                       = hiera('contrail::aaa_mode', 'cloud-admin'),
+  $analytics_aaa_mode             = hiera('contrail::analytics_aaa_mode', 'cloud-admin'),
+
+  $admin_password                 = hiera('contrail::admin_password', undef),
+  $admin_port                     = 35357,
+  $admin_tenant                   = hiera('contrail::admin_tenant_name', undef),
+  $admin_user                     = hiera('contrail::admin_user', undef),
+  $auth_host                      = hiera('contrail::auth_host', undef),
+  $auth_protocol                  = hiera('contrail::auth_protocol', 'http'),
+  $insecure                       = hiera('contrail::insecure', true),
+  $ssl_enabled                    = hiera('contrail_ssl_enabled', false),
+
+  $analytics_list                 = hiera('contrail_analytics_node_ips', undef),
+
+  $analyticsdb_list               = hiera('contrail_analytics_database_node_ips', undef),
+  $analyticsdb_cassandra_user     = hiera('contrail_analyticsdb_cassandra_user', 'contrail_analyticsdb_cassandra_user'),
+  $analyticsdb_cassandra_password = hiera('contrail_analyticsdb_cassandra_password', 'contrail_analyticsdb_cassandra_password'),
+
+  $cloud_orchestrator             = hiera('contrail_cloud_orchestrator', 'openstack'),
+
+  $controller_list                = hiera('contrail_config_node_ips', undef),
+  $configdb_cassandra_user        = hiera('contrail_configdb_cassandra_user', 'contrail_configdb_cassandra_user'),
+  $configdb_cassandra_password    = hiera('contrail_configdb_cassandra_password', 'contrail_configdb_cassandra_password'),
+
+  $controller_virtual_ip          = hiera('controller_virtual_ip', '127.0.0.1'),
+  $glance_api_ip                  = hiera('glance_api_vip', $controller_virtual_ip),
+  $neutron_metadata_ip            = hiera('neutron::agents::metadata::metadata_ip',
+                                        hiera('nova_metadata_vip', $controller_virtual_ip)),
+  $nova_api_ip                    = hiera('nova_api_vip', $controller_virtual_ip),
+
+  $external_rabbitmq_list         = hiera('rabbitmq_node_ips', undef),
+  $rabbitmq_user                  = hiera('contrail::rabbit_user', 'contrail_rabbitmq_user'),
+  $rabbitmq_password              = hiera('contrail::rabbit_password', 'contrail_rabbitmq_password'),
+  $rabbitmq_vhost                 = hiera('contrail::rabbitmq_vhost', undef),
+) {
+
+  if $auth_protocol == 'https' {
+    $auth_port_public = hiera('contrail::auth_port_ssl_public', undef)
+    $cafile = hiera('contrail::service_certificate', undef)
+    $certfile = hiera('contrail::service_certificate', undef)
+  } else {
+    $auth_port_public = hiera('contrail::auth_port_public', 5000)
+    $cafile = undef
+    $certfile = undef
+  }
+
+  $analytics_nodes = join($analytics_list, ',')
+  $analyticsdb_nodes = join($analyticsdb_list, ',')
+  $controller_nodes = join($controller_list, ',')
+  $external_rabbitmq_servers = $external_rabbitmq_list ? {
+    undef   => undef,
+    default => join($external_rabbitmq_list, ','),
+  }
+
+  file { "${config_file_dir}/${config_file}" :
+    ensure  => file,
+    content => template("${template_file_dir}/${template_file}"),
+  }
+}

--- a/manifests/container/install.pp
+++ b/manifests/container/install.pp
@@ -1,0 +1,51 @@
+
+define contrail::container::install (
+  $container_file  = undef,
+  $container_image = undef,
+  $container_name  = $title,
+  $container_url   = undef,
+) {
+  package { 'docker-engine' :
+    ensure => installed,
+  } ->
+  service { 'docker' :
+    ensure => 'running',
+    enable => true,
+  }
+  $local_file = $container_file ? {
+    undef   => "/tmp/${container_name}.tar.gz",
+    default => $container_file,
+  }
+  $check_docker_image_cmd="docker images | awk '{print(\$1\":\"\$2)}' | grep -q '${container_image}'"
+  $repo_url = $::contrail_repo_url ? {
+    undef   => undef,
+    ''      => undef,
+    default => $::contrail_repo_url,
+  }
+  if $container_url or $repo_url {
+    $url = $container_url ? {
+      undef   => "${repo_url}/${container_name}.tar.gz",
+      default => "${container_url}/${container_name}.tar.gz",
+    }
+    package { 'wget' :
+      ensure => installed,
+    } ->
+    exec { "Dowload ${url}":
+      path    => '/usr/bin:/usr/sbin:/bin',
+      command => "wget --tries 5 --waitretry=2 --retry-connrefused -O ${local_file} ${url}",
+      onlyif  => "[ ! -f ${local_file} ]",
+      unless  => $check_docker_image_cmd,
+      require => Service['docker'],
+      before  => Exec["pull ${container_name} container to docker"],
+    }
+  }
+  exec { "pull ${container_name} container to docker" :
+    path    => '/usr/bin:/usr/sbin:/bin',
+    command => "docker load -i ${local_file}",
+    unless  => $check_docker_image_cmd,
+    require => Service['docker'],
+  } ->
+  file { '/etc/contrailctl':
+    ensure => directory,
+  }
+}

--- a/manifests/container/run.pp
+++ b/manifests/container/run.pp
@@ -1,0 +1,24 @@
+
+define contrail::container::run (
+  $cloud_orchestrator = hiera('contrail_cloud_orchestrator', 'openstack'),
+  $container_name     = $title,
+  $container_image    = undef,
+) {
+
+    $docker_net_opts = '--net=host'
+    $docker_vol_opts = '--volume=/etc/contrailctl:/etc/contrailctl'
+    $docker_env_opts = "--env='CLOUD_ORCHESTRATOR=${cloud_orchestrator}'"
+    $docker_common_opts = '--restart=always --cap-add=AUDIT_WRITE --privileged'
+    $docker_opts = "$docker_common_opts $docker_net_opts $docker_env_opts $docker_vol_opts"
+    $check_cmd = "docker ps --all | grep -q '${container_name}'"
+    exec { "create ${container_name} container" :
+      path    => '/usr/bin:/usr/sbin:/bin',
+      command => "docker create --name='${container_name}' ${docker_opts} ${container_image}",
+      unless  => $check_cmd,
+    } ->
+    exec { "start ${container_name} container" :
+      path    => '/usr/bin:/usr/sbin:/bin',
+      command => "docker start $(docker ps --all | awk '/${container_name}/{print(\$1)}')",
+      onlyif  => $check_cmd,
+    }
+}

--- a/manifests/control.pp
+++ b/manifests/control.pp
@@ -8,24 +8,27 @@
 #   (optional) Package name for control
 #
 class contrail::control (
-  $control_config         = {},
-  $control_nodemgr_config = {},
-  $dns_config             = {},
-  $package_name           = $contrail::params::control_package_name,
+  $control_config           = {},
+  $control_nodemgr_config   = {},
+  $dns_config               = {},
+  $package_name             = $contrail::params::control_package_name,
   $secret,
   $manage_named           = 'true',
 ) inherits contrail::params {
 
-  anchor {'contrail::control::start': } ->
-  class {'::contrail::control::install': } ->
-  class {'::contrail::control::config':
-    control_config         => $control_config,
-    control_nodemgr_config => $control_nodemgr_config,
-    dns_config             => $dns_config,
-    secret                 => $secret,
-    manage_named           => $manage_named,
-  } ~>
-  class {'::contrail::control::service': }
-  anchor {'contrail::control::end': }
-  
+  if $version < 4 {
+    anchor {'contrail::control::start': } ->
+    class {'::contrail::control::install': } ->
+    class {'::contrail::control::config':
+      control_config         => $control_config,
+      control_nodemgr_config => $control_nodemgr_config,
+      dns_config             => $dns_config,
+      secret                 => $secret,
+      manage_named           => $manage_named,
+    } ~>
+    class {'::contrail::control::service': }
+    anchor {'contrail::control::end': }
+  } else {
+    notify { "Skip Contrail-Control configuration in container based deploument": }
+  }
 }

--- a/manifests/control/provision_encap.pp
+++ b/manifests/control/provision_encap.pp
@@ -49,18 +49,21 @@ class contrail::control::provision_encap (
   $keystone_admin_password    = 'password',
   $keystone_admin_tenant_name = 'admin',
   $oper                       = 'add',
-) {
+) inherits contrail::params {
 
-  exec { "provision_encap.py ${api_address}" :
-    path => '/usr/bin',
-    command => "python /opt/contrail/utils/provision_encap.py \
-                 --api_server_ip ${api_address} \
-                 --api_server_port ${api_port} \
-                 --encap_priority ${encap_priority} \
-                 --vxlan_vn_id_mode ${vxlan_vn_id_mode} \
-                 --admin_user ${keystone_admin_user} \
-                 --admin_password ${keystone_admin_password} \
-                 --oper ${oper}",
+  if $version < 4 {
+    exec { "provision_encap.py ${api_address}" :
+      path => '/usr/bin',
+      command => "python /opt/contrail/utils/provision_encap.py \
+                  --api_server_ip ${api_address} \
+                  --api_server_port ${api_port} \
+                  --encap_priority ${encap_priority} \
+                  --vxlan_vn_id_mode ${vxlan_vn_id_mode} \
+                  --admin_user ${keystone_admin_user} \
+                  --admin_password ${keystone_admin_password} \
+                  --oper ${oper}",
+    }
+  } else {
+    notify { "Skip Contrail control provision encap in container based deploument": }
   }
-
 }

--- a/manifests/control/provision_linklocal.pp
+++ b/manifests/control/provision_linklocal.pp
@@ -64,22 +64,25 @@ class contrail::control::provision_linklocal (
   $keystone_admin_password    = 'password',
   $keystone_admin_tenant_name = 'admin',
   $oper                       = 'add',
-) {
+) inherits contrail::params {
 
-  exec { "provision_linklocal.py ${api_address}" :
-    path => '/usr/bin',
-    command => "python /opt/contrail/utils/provision_linklocal.py \
-                 --api_server_ip ${api_address} \
-                 --api_server_port ${api_port} \
-                 --linklocal_service_name ${linklocal_service_name} \
-                 --linklocal_service_ip ${linklocal_service_ip} \
-                 --linklocal_service_port ${linklocal_service_port} \
-                 --ipfabric_service_ip ${ipfabric_service_ip} \
-                 --ipfabric_service_port ${ipfabric_service_port} \
-                 --admin_user ${keystone_admin_user} \
-                 --admin_password ${keystone_admin_password} \
-                 --admin_tenant ${keystone_admin_tenant_name} \
-                 --oper ${oper}",
+  if $version < 4 {
+    exec { "provision_linklocal.py ${api_address}" :
+      path => '/usr/bin',
+      command => "python /opt/contrail/utils/provision_linklocal.py \
+                  --api_server_ip ${api_address} \
+                  --api_server_port ${api_port} \
+                  --linklocal_service_name ${linklocal_service_name} \
+                  --linklocal_service_ip ${linklocal_service_ip} \
+                  --linklocal_service_port ${linklocal_service_port} \
+                  --ipfabric_service_ip ${ipfabric_service_ip} \
+                  --ipfabric_service_port ${ipfabric_service_port} \
+                  --admin_user ${keystone_admin_user} \
+                  --admin_password ${keystone_admin_password} \
+                  --admin_tenant ${keystone_admin_tenant_name} \
+                  --oper ${oper}",
+    }
+  } else {
+    notify { "Skip Contrail control provision linklocal in container based deploument": }
   }
-
 }

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -4,30 +4,36 @@
 #
 # === Parameters:
 #
+# [*version*]
+#   (optional) Use container based deployment
+#   Default to 'false'
 # [*package_name*]
 #   (optional) Package name for database
 #
 class contrail::database (
-  $package_name = $contrail::params::database_package_name,
-  $database_params = $database_params,
+  $package_name         = $contrail::params::database_package_name,
+  $database_params      = $database_params,
 ) inherits contrail::params {
 
-  Service <| name == 'supervisor-analytics' |> -> Service['supervisor-database']
-  Service <| name == 'supervisor-config' |> -> Service['supervisor-database']
-  Service <| name == 'supervisor-control' |> -> Service['supervisor-database']
-  Service['supervisor-database'] -> Service <| name == 'supervisor-webui' |>
+  if $version < 4 {
+    Service <| name == 'supervisor-analytics' |> -> Service['supervisor-database']
+    Service <| name == 'supervisor-config' |> -> Service['supervisor-database']
+    Service <| name == 'supervisor-control' |> -> Service['supervisor-database']
+    Service['supervisor-database'] -> Service <| name == 'supervisor-webui' |>
 
-  anchor {'contrail::database::start': } ->
-  class {'::contrail::database::install': } ->
-  class {'::contrail::database::config': 
-    cassandra_servers       => $database_params['cassandra_servers'],
-    cassandra_ip            => $database_params['host_ip'],
-    database_nodemgr_config => $database_params['database_nodemgr_config'],
-    zookeeper_server_ips    => $database_params['zookeeper_server_ips'],
-    zookeeper_client_ip     => $database_params['zookeeper_client_ip'],
-    zookeeper_hostnames     => $database_params['zookeeper_hostnames'],
-  } ~>
-  class {'::contrail::database::service': }
-  anchor {'contrail::database::end': }
-  
+    anchor {'contrail::database::start': } ->
+    class {'::contrail::database::install': } ->
+    class {'::contrail::database::config':
+      cassandra_servers       => $database_params['cassandra_servers'],
+      cassandra_ip            => $database_params['host_ip'],
+      database_nodemgr_config => $database_params['database_nodemgr_config'],
+      zookeeper_server_ips    => $database_params['zookeeper_server_ips'],
+      zookeeper_client_ip     => $database_params['zookeeper_client_ip'],
+      zookeeper_hostnames     => $database_params['zookeeper_hostnames'],
+    } ~>
+    class {'::contrail::database::service': }
+    anchor {'contrail::database::end': }
+  } else {
+    notify { "Skip Contrail-Database configuration in container based deploument": }
+  }
 }

--- a/manifests/database/provision_database.pp
+++ b/manifests/database/provision_database.pp
@@ -39,14 +39,16 @@
 class contrail::database::provision_database (
   $api_address                = '127.0.0.1',
   $api_port                   = 8082,
-  $database_node_address       = $host_ip,
-  $database_node_name          = $::hostname,
+  $database_node_address      = $host_ip,
+  $database_node_name         = $::hostname,
   $keystone_admin_user        = 'admin',
   $keystone_admin_password    = 'password',
   $keystone_admin_tenant_name = 'admin',
   $oper                       = 'add',
   $openstack_vip              = '127.0.0.1',
-) {
+) inherits contrail::params {
+
+if $version < 4 {
 
   #exec { "database deploy wait for keystone become available" :
   #  path => '/usr/bin',
@@ -70,5 +72,11 @@ class contrail::database::provision_database (
                  --oper ${oper}",
     tries => 100,
     try_sleep => 3,
+  }
+  } else {
+
+    # Container based deployment
+
+    notify { 'Skip Contrail provision database step in container based deployment': }
   }
 }

--- a/manifests/heat.pp
+++ b/manifests/heat.pp
@@ -4,17 +4,22 @@
 #
 # === Parameters:
 #
+
 class contrail::heat (
   $heat_config,
 ) inherits contrail::params  {
 
-  anchor {'contrail::heat::start': } ->
-  class {'::contrail::heat::install': } ->
-  class {'::contrail::heat::config': 
-    heat_config => $heat_config,
+  if $version < 4 {
+    anchor {'contrail::heat::start': } ->
+    class {'::contrail::heat::install': } ->
+    class {'::contrail::heat::config':
+      heat_config => $heat_config,
+    }
+    #} ~>
+    #class {'::contrail::heat::service': }
+    anchor {'contrail::heat::end': }
+  } else {
+    notify { "Skip Contrail-Heat configuration in container based deploument": }
   }
-  #} ~>
-  #class {'::contrail::heat::service': }
-  anchor {'contrail::heat::end': }
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,14 +1,16 @@
 # == Class: contrail::params
 #
 class contrail::params(
-  $analytics         = {},
-  $analyticsdatabase = {},
-  $config            = {},
-  $control           = {},
-  $database          = {},
-  $webui             = {},
-){
-
+  $analytics                  = {},
+  $analyticsdatabase          = {},
+  $container_tag              = '4.0.0.0-20',
+  $container_url              = undef,
+  $config                     = {},
+  $control                    = {},
+  $database                   = {},
+  $webui                      = {},
+  $version                    = 4,
+) {
   $control_package_name = ['contrail-openstack-control']
   $config_package_name = ['contrail-openstack-config']
   $analytics_package_name = ['contrail-openstack-analytics']
@@ -16,4 +18,17 @@ class contrail::params(
   $database_package_name = ['contrail-openstack-database']
   $vrouter_package_name = ['contrail-openstack-vrouter']
 
+  if $::osfamily != 'RedHat' {
+    $container_ver=downcase("${::operatingsystem}${::operatingsystemrelease}")
+  } else {
+    $container_ver='redhat7'
+  }
+
+  $analytics_container_name = "contrail-analytics-${container_ver}-${container_tag}"
+  $analyticsdb_container_name = "contrail-analyticsdb-${container_ver}-${container_tag}"
+  $controller_container_name = "contrail-controller-${container_ver}-${container_tag}"
+
+  $analytics_container_image = "contrail-analytics-${container_ver}:${container_tag}"
+  $analyticsdb_container_image = "contrail-analyticsdb-${container_ver}:${container_tag}"
+  $controller_container_image = "contrail-controller-${container_ver}:${container_tag}"
 }

--- a/manifests/provision_analytics.pp
+++ b/manifests/provision_analytics.pp
@@ -7,8 +7,12 @@
 # This class is simply an helper to be included when all three provisions needs
 # to be done
 #
-class contrail::provision_analytics {
+class contrail::provision_analytics (
+) inherits contrail::params {
 
-  include ::contrail::control::provision_analytics
-
+  if $version < 4 {
+    include ::contrail::control::provision_analytics
+  } else {
+    notify { "Skip Contrail provision analytics in container based deploument": }
+  }
 }

--- a/manifests/provision_config.pp
+++ b/manifests/provision_config.pp
@@ -7,8 +7,12 @@
 # This class is simply an helper to be included when all three provisions needs
 # to be done
 #
-class contrail::provision_config {
+class contrail::provision_config  (
+) inherits contrail::params {
 
-  include ::contrail::control::provision_config
-
+  if $version < 4 {
+    include ::contrail::control::provision_config
+  } else {
+    notify { "Skip Contrail provision analytics in container based deploument": }
+  }
 }

--- a/manifests/provision_control.pp
+++ b/manifests/provision_control.pp
@@ -9,10 +9,14 @@
 # This class is simply an helper to be included when all three provisions needs
 # to be done
 #
-class contrail::provision_control {
+class contrail::provision_control(
+) inherits contrail::params {
 
-  include ::contrail::control::provision_control
-  include ::contrail::control::provision_linklocal
-  include ::contrail::control::provision_encap
-
+  if $version < 4 {
+    include ::contrail::control::provision_control
+    include ::contrail::control::provision_linklocal
+    include ::contrail::control::provision_encap
+ } else {
+    notify { "Skip Contrail provision control in container based deploument": }
+  }
 }

--- a/manifests/provision_database.pp
+++ b/manifests/provision_database.pp
@@ -7,8 +7,12 @@
 # This class is simply an helper to be included when all three provisions needs
 # to be done
 #
-class contrail::provision_database {
+class contrail::provision_database (
+) inherits contrail::params {
 
-  include ::contrail::control::provision_database
-
+  if $version < 4 {
+    include ::contrail::control::provision_database
+  } else {
+    notify { "Skip Contrail provision database in container based deploument": }
+  }
 }

--- a/manifests/vrouter/config.pp
+++ b/manifests/vrouter/config.pp
@@ -75,7 +75,7 @@ class contrail::vrouter::config (
   $vrouter_agent_config   = {},
   $vrouter_nodemgr_config = {},
   $vnc_api_lib_config     = {},
-) {
+) inherits contrail::params {
 
 #  include ::contrail::vnc_api
 #  include ::contrail::ctrl_details
@@ -85,19 +85,94 @@ class contrail::vrouter::config (
     ensure => file,
   }
 
-  validate_hash($vrouter_agent_config)
-  validate_hash($vrouter_nodemgr_config)
-  validate_hash($keystone_config)
+  if $version < 4 {
+    $keystone_cfg = $keystone_config
+    $agent_cfg    = $vrouter_agent_config
+    $nodemgr_cfg  = $vrouter_nodemgr_config
+    $vnc_api_cfg  = $vnc_api_lib_config
+  } else {
+    $keystone_cfg = undef
+    $_keystone_cfg = $keystone_config['KEYSTONE']
+    # TODO: read parameters from input paramerers
+    $_web_server = hiera('contrail_config_vip', hiera('internal_api_virtual_ip'))
+    $_web_port = hiera('contrail::api_port', 8082)
+    $_vnc_api_cfg_blobal = {
+      'global' => {
+        'WEB_SERVER'  => $_web_server,
+        'WEB_PORT'    => $_web_port,
+      }
+    }
+    if $_keystone_cfg and $_keystone_cfg['auth_host'] {
+      $_vnc_api_cfg_auth = {
+        'auth' => {
+          'AUTHN_TYPE'      => 'keystone',
+          'AUTHN_SERVER'    => $_keystone_cfg['auth_host'],
+          'AUTHN_PROTOCOL'  => $_keystone_cfg['auth_protocol'],
+          'AUTHN_PORT'      => $_keystone_cfg['auth_port'],
+          'insecure'        => $_keystone_cfg['insecure'],
+          'certfile'        => $_keystone_cfg['certfile'],
+          'cafile'          => $_keystone_cfg['cafile'],
+        }
+      }
+    } else {
+      $_vnc_api_cfg_auth = {
+        'auth' => {
+          'AUTHN_TYPE' => 'noauth',
+        }
+      }
+    }
+    $vnc_api_cfg = deep_merge($_vnc_api_cfg_blobal, $_vnc_api_cfg_auth)
 
-  $contrail_keystone_config = { 'path' => '/etc/contrail/contrail-keystone-auth.conf' }
+    $_analytics_nodes = join(suffix(hiera('contrail_analytics_node_ips'), ':8086'), ' ')
+    $nodemgr_cfg = {
+      'COLLECTOR' => {
+        'server_list' => $_analytics_nodes,
+      }
+    }
+
+    $_cfg_nodes = hiera('contrail_config_node_ips')
+    $_control_nodes = join(suffix($_cfg_nodes, ':5269'), ' ')
+    $_dns_nodes = join(suffix($_cfg_nodes, ':53'), ' ')
+    # TODO: probably use another parameter, e.g. insecure
+    $_ssl_enabled = hiera('contrail_ssl_enabled', false)
+    $_agent_cfg = {
+      'CONTROL-NODE' => {
+        'servers' => $_control_nodes,
+      },
+      'DNS' => {
+        'servers' => $_dns_nodes,
+      },
+      'DEFAULT' => {
+        'collectors'                      => $_analytics_nodes,
+        'xmpp_auth_enable'                => $_ssl_enabled,
+        'xmpp_dns_auth_enable'            => $_ssl_enabled,
+
+      },
+      'SANDESH' => {
+        'introspect_ssl_enable'           => $_ssl_enabled,
+        'sandesh_ssl_enable'              => $_ssl_enabled,
+      }
+    }
+
+    $agent_cfg = deep_merge($vrouter_agent_config, $_agent_cfg)
+  }
+
+  validate_hash($agent_cfg)
+  validate_hash($nodemgr_cfg)
+  validate_hash($vnc_api_cfg)
+
   $contrail_vrouter_agent_config = { 'path' => '/etc/contrail/contrail-vrouter-agent.conf' }
   $contrail_vrouter_nodemgr_config = { 'path' => '/etc/contrail/contrail-vrouter-nodemgr.conf' }
   $contrail_vnc_api_lib_config = { 'path' => '/etc/contrail/vnc_api_lib.ini' }
 
-  create_ini_settings($keystone_config, $contrail_keystone_config)
-  create_ini_settings($vrouter_agent_config, $contrail_vrouter_agent_config)
-  create_ini_settings($vrouter_nodemgr_config, $contrail_vrouter_nodemgr_config)
-  create_ini_settings($vnc_api_lib_config, $contrail_vnc_api_lib_config)
+  if $keystone_cfg {
+    validate_hash($keystone_cfg)
+    $contrail_keystone_config = { 'path' => '/etc/contrail/contrail-keystone-auth.conf' }
+    create_ini_settings($keystone_cfg, $contrail_keystone_config)
+  }
+  create_ini_settings($agent_cfg, $contrail_vrouter_agent_config)
+  create_ini_settings($nodemgr_cfg, $contrail_vrouter_nodemgr_config)
+  create_ini_settings($vnc_api_cfg, $contrail_vnc_api_lib_config)
 
   if $step == 5 and !$is_tsn {
     file { '/nova_libvirt.patch' :
@@ -156,7 +231,7 @@ class contrail::vrouter::config (
     file { '/opt/contrail/utils/update_dev_net_config_files.py':
       ensure => file,
       source => '/usr/share/openstack-puppet/modules/contrail/files/vrouter/update_dev_net_config_files.py',
-    } -> 
+    } ->
     exec { '/bin/python /opt/contrail/utils/update_dev_net_config_files.py' :
       path => '/usr/bin',
       command => "/bin/python /opt/contrail/utils/update_dev_net_config_files.py \

--- a/manifests/webui.pp
+++ b/manifests/webui.pp
@@ -6,11 +6,11 @@
 #
 # [*package_name*]
 #   (optional) Package name for webui
-#
+
 class contrail::webui (
-  $package_name = $contrail::params::webui_package_name,
+  $package_name             = $contrail::params::webui_package_name,
   $openstack_vip,
-  $cert_file               = '',
+  $cert_file                = '',
   $contrail_config_vip,
   $contrail_analytics_vip,
   $neutron_vip,
@@ -26,27 +26,30 @@ class contrail::webui (
   $redis_ip,
 ) inherits contrail::params {
 
-  anchor {'contrail::webui::start': } ->
-  class {'::contrail::webui::install': } ->
-  class {'::contrail::webui::config': 
-    openstack_vip             => $openstack_vip,
-    contrail_config_vip       => $contrail_config_vip,
-    contrail_analytics_vip    => $contrail_analytics_vip,
-    neutron_vip               => $neutron_vip,
-    cassandra_ip              => $cassandra_ip,
-    cert_file                 => $cert_file,
-    redis_ip                  => $redis_ip,
-    contrail_webui_http_port  => $contrail_webui_http_port,
-    contrail_webui_https_port => $contrail_webui_https_port,
-    admin_user                => $admin_user,
-    admin_password            => $admin_password,
-    admin_token               => $admin_token,
-    admin_tenant_name         => $admin_tenant_name,
-    auth_port                 => $auth_port,
-    auth_protocol             => $auth_protocol,
-#  } ~>
-  } ->
-  class {'::contrail::webui::service': }
-  anchor {'contrail::webui::end': }
-  
+  if $version < 4 {
+
+    anchor {'contrail::webui::start': } ->
+    class {'::contrail::webui::install': } ->
+    class {'::contrail::webui::config':
+      openstack_vip             => $openstack_vip,
+      contrail_config_vip       => $contrail_config_vip,
+      contrail_analytics_vip    => $contrail_analytics_vip,
+      neutron_vip               => $neutron_vip,
+      cassandra_ip              => $cassandra_ip,
+      cert_file                 => $cert_file,
+      redis_ip                  => $redis_ip,
+      contrail_webui_http_port  => $contrail_webui_http_port,
+      contrail_webui_https_port => $contrail_webui_https_port,
+      admin_user                => $admin_user,
+      admin_password            => $admin_password,
+      admin_token               => $admin_token,
+      admin_tenant_name         => $admin_tenant_name,
+      auth_port                 => $auth_port,
+      auth_protocol             => $auth_protocol,
+    } ->
+    class {'::contrail::webui::service': }
+    anchor {'contrail::webui::end': }
+  } else {
+    notify { "Skip Contrail-Web configuration in container based deploument": }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
-  "name": "eNovance-contrail",
-  "version": "1.0.0",
+  "name": "puppet-contrail",
+  "version": "2.0.0",
   "author": "Yanis Guenane, Sebastien Badia, and eNovance Contributors",
   "summary": "Puppet module for Juniper OpenContrail",
   "license": "Apache-2.0",
-  "source": "git://github.com/redhat-cip/puppet-contrail.git",
-  "project_page": "https://github.com/redhat-cip/puppet-contrail",
-  "issues_url": "https://github.com/redhat-cip/puppet-contrail/issues",
+  "source": "git://github.com/Juniper/puppet-contrail.git",
+  "project_page": "https://github.com/Juniper/puppet-contrail",
+  "issues_url": "https://github.com/Juniper/puppet-contrail/issues",
   "description": "Installs and configures OpenContrail.",
   "operatingsystem_support": [
     {

--- a/templates/contrailctl/analytics.conf.erb
+++ b/templates/contrailctl/analytics.conf.erb
@@ -1,0 +1,281 @@
+[GLOBAL]
+# All global configurations which would affect multiple sections or globally
+# applicable configurations would be coming here.
+
+# Default log_level
+# log_level = SYS_NOTICE
+
+#external_lb - Flag to identify the whether the loadbalancer is internaly
+# hosted in the lb container or it is externally managed. Based on which
+# the listen port of thecontrail-analytics-api will be decided.
+# Default is False (Internally hosted in lb container)
+#
+# external_lb = False
+
+
+# cloud_orchestrator - what cloud orchestrator is being used. Valid options:
+#  kubernetes, openstack, mesos
+# cloud_orchestrator = kubernetes
+<% if defined?(@cloud_orchestrator) %>
+cloud_orchestrator = <%= @cloud_orchestrator %>
+<% end -%>
+
+# hosts_entries: (OPTIONAL) a dict in form of {name1: 1.1.1.1, name2: 1.1.1.2}
+# In multi-controller systems, all hosts in the cluster should be reachable
+# using its own hostname which is requirement for rabbitmq, so for that /etc/hosts
+# entries are required, unless there is an external dns infrastructure to support it
+# Alternatively one can write /etc/hosts entries on the host before starting
+# the container, in which case container will take those entries.
+# hosts_entries = {"host1": "1.1.1.1", "host2": "1.1.1.2"}
+
+# controller_nodes - Comma separated list of controller server IP addresses
+# - this will be used to configure rabbitmq, zookeeper, cassandra servers in
+# various contrail service configurations and configure load balancer for various
+# contrail services that needed to be loadbalanced
+# controller_nodes = 127.0.0.1
+controller_nodes = <%= @controller_nodes %>
+
+# analyticsdb_nodes - Comma separated list of analyticsdb server IP
+# addresses - this will be used to configure cassandra, and kafka servers
+# in various contrail service configurations.
+# This should be list of IP addresses where cassandra and kafka listening
+# analyticsdb_nodes = 127.0.0.1
+analyticsdb_nodes = <%= @analyticsdb_nodes %>
+
+# controller_ip - An IP address using which one can connect to all public
+# services within controller container. This can be a virtual IP handled by
+# load balancer in case of multi-node controllers. This will be configured
+# in various contrail services configurations to connect to other set of
+# services like discovery_server_ip.
+# controller_ip = 127.0.0.1
+
+# analytics_nodes - Comma separated list of analytics server IP addresses
+# analytics_nodes = 127.0.0.1
+analytics_nodes = <%= analytics_nodes %>
+
+# external servers are those common services like zookeeper, rabbitmq, cassandra
+# which are configured and managed external to contrail cluster and given
+# to contrail services to use them. In this case those services will not be
+# deployed in contrail controller container. Instead the contrail services
+# are configured to use those external services. Also none of our code will
+# try to deploy/configure/manage any of the external services
+# external_rabbitmq_servers, external_zookeeper_servers,
+# external_cassandra_servers - Comma separated list of rabbitmq, zookeeper,
+# and cassandra respectively.
+# Example external_zookeeper_servers = 10.0.0.1,10.0.0.2
+# external_rabbitmq_servers =
+# external_zookeeper_servers =
+# external_configdb_servers =
+<% if defined?(@external_rabbitmq_servers) %>
+external_rabbitmq_servers = <%= @external_rabbitmq_servers %>
+<% end -%>
+<% if defined?(@external_zookeeper_servers) %>
+external_zookeeper_servers = <%= @external_zookeeper_servers %>
+<% end -%>
+<% if defined?(@external_configdb_servers) %>
+external_configdb_servers = <%= @external_configdb_servers %>
+<% end -%>
+<% if defined?(@external_cassandra_servers) %>
+external_cassandra_servers = <%= @external_cassandra_servers %>
+<% end -%>
+
+# uve_partition_count - UVE data is partitioned to improve analytics performance,
+# this configuration set number of partitions
+# uve_partition_count = 30
+
+<% if defined?(@ssl_enabled) %>
+# Enable/Disable ssl for sandesh connection
+# sandesh_ssl_enable = False
+sandesh_ssl_enable = <%= @ssl_enabled %>
+
+# Enable/Disable ssl for introspect connection
+# introspect_ssl_enable = False
+introspect_ssl_enable = <%= @ssl_enabled %>
+
+# xmpp_auth_enable and xmpp_dns_auth_enable are two flags used to configure
+# contrail-control and contrail-dns services to use SSL certs to communicate
+# with the vrouter agent
+xmpp_auth_enable = <%= @ssl_enabled %>
+xmpp_dns_auth_enable = <%= @ssl_enabled %>
+
+<% end -%>
+
+<% if defined?(@analyticsdb_cassandra_user) %>
+analyticsdb_cassandra_user = <%= @analyticsdb_cassandra_user %>
+<% end -%>
+<% if defined?(@analyticsdb_cassandra_password) %>
+analyticsdb_cassandra_password = <%= @analyticsdb_cassandra_password %>
+<% end -%>
+
+# Redis password, default is None
+# redis_password = redis
+
+<% if defined?(@cloud_orchestrator) && @cloud_orchestrator == "openstack" %>
+# [KEYSTONE] - Section to get informtion about the keystone to be used by contrail,
+# Required only when orchestration is 'openstack' and keystone is managed
+# externally out of ansible.
+#
+[KEYSTONE]
+# version - Version of keystone to be used.
+# version = v2.0
+
+# ip - Ip address of the host running keystone
+# ip = 127.0.0.1
+ip = <%= @auth_host %>
+
+# admin_port - Keystone admin port in which the keystone is listening.
+# admin_port = 35357
+admin_port = <%= @admin_port %>
+
+# public_port - Keystone public port in which the keystone is listening.
+# public_port = 5000
+public_port = <%= @auth_port_public %>
+
+# auth_protocol -  Protocol used by keystone(http/https)
+# auth_protocol = http
+auth_protocol = <%= @auth_protocol %>
+
+# admin_user - Name of the admin user in keystone.
+# admin_user = admin
+admin_user = <%= @admin_user %>
+
+# admin_password - Password of the keystone admin user.
+# admin_password = admin
+admin_password = <%= @admin_password %>
+
+# admin_tenant - keystone admin tenant's name.
+# admin_tenant = admin
+admin_tenant = <%= @admin_tenant %>
+
+#insecure - Whether to validate Keystone SSL certificate.
+#insecure = False
+insecure = <%= @insecure %>
+
+<% if @auth_protocol == "https" %>
+#certfile - Keystone SSL certificate to install and use for API ports
+#certfile = /etc/contrailctl/ssl/server.pem
+<% if defined?(@certfile) && @certfile != "" %>
+certfile = <%= @certfile %>
+<% end -%>
+
+#keyfile - Keystone SSL key to use with certificate.
+#keyfile = /etc/contrailctl/ssl/server-privatekey.pem
+<% if defined?(@keyfile) && @keyfile != "" %>
+keyfile = <%= @keyfile %>
+<% end -%>
+
+#cafile - Keystone SSL CA to use with the certificate and key provided
+#Required only if using privately signed certfile and keyfile
+#cafile = /etc/contrailctl/ssl/ca-cert.pem
+<% if defined?(@cafile) && @cafile != "" %>
+cafile = <%= @cafile %>
+<% end -%>
+
+<% end -%>
+
+<% end -%>
+
+
+[ALARM_GEN]
+# Log file and log level
+# log = /var/log/contrail/contrail-alarm-gen.log
+# log_level = SYS_NOTICE
+#
+# Introspect port for debug
+# introspect_port = 5995
+
+[ANALYTICS_API]
+# Introspect port for debug
+# introspect_port = 8090
+#
+# Listen address and port
+# listen_port = 8081
+# listen_address = 0.0.0.0
+#
+# Log file and log_level
+# log_level = SYS_NOTICE
+# log = /var/log/contrail/contrail-analytics-api.log
+#
+# aaa_mode - RBAC configuration for analytics api
+#   no-auth - no authentication is performed and full access is granted to all
+#   cloud-admin - authentication is performed and only cloud-admin role has
+#                 access - default cloud-admin role is "admin"
+#   rbac RBAC - authentication is performed and access granted based on role
+#               and configured rules
+# aaa_mode = no-auth
+<% if defined?(@analytics_aaa_mode) %>
+aaa_mode = <%= @analytics_aaa_mode %>
+<% end -%>
+
+
+
+[ANALYTICS_COLLECTOR]
+# log file name and log_level
+# log = /var/log/contrail/contrail-collector.log
+# Log severity levels. Possible values are SYS_EMERG, SYS_ALERT, SYS_CRIT,
+# SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO and SYS_DEBUG. Default is SYS_DEBUG
+# log_level = SYS_NOTICE
+#
+# Introspect port for debug
+# introspect_port = 8089
+#
+# Listen address and port
+# listen_port = 8086
+# listen_address = 0.0.0.0
+#
+# syslog_port = -1
+# analytics_data_ttl = 48
+# analytics_config_audit_ttl = 2160
+# analytics_statistics_ttl = 24
+# analytics_flow_ttl = 2
+
+[QUERY_ENGINE]
+# log file name and log_level
+# log = /var/log/contrail/contrail-query-engine.log
+# Log severity levels. Possible values are SYS_EMERG, SYS_ALERT, SYS_CRIT,
+# SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO and SYS_DEBUG. Default is SYS_DEBUG
+# log_level = SYS_NOTICE
+#
+# Introspect port for debug
+# introspect_port = 8091
+
+[SNMP_COLLECTOR]
+# log file name and log_level
+# log = /var/log/contrail/contrail-snmp-collector.log
+# Log severity levels. Possible values are SYS_EMERG, SYS_ALERT, SYS_CRIT,
+# SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO and SYS_DEBUG. Default is SYS_DEBUG
+# log_level = SYS_NOTICE
+#
+# Introspect port for debug
+# introspect_port = 5920
+#
+# scan_frequency=600
+#
+# fast_scan_frequency=60
+
+[TOPOLOGY]
+# log file name and log_level
+# log = /var/log/contrail/contrail-topology.log
+# Log severity levels. Possible values are SYS_EMERG, SYS_ALERT, SYS_CRIT,
+# SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO and SYS_DEBUG. Default is SYS_DEBUG
+# log_level = SYS_NOTICE
+#
+# Introspect port for debug
+# introspect_port = 5921
+
+[RABBITMQ]
+# All rabbitmq releated parameters used to
+# configure alarm-gen service in analytics contianer
+#
+# vhost = '/'
+<% if defined?(@rabbitmq_vhost) %>
+vhost = <%= @rabbitmq_vhost %>
+<% end -%>
+# user = guest
+<% if defined?(@rabbitmq_user) %>
+user = <%= @rabbitmq_user %>
+<% end -%>
+# password = guest
+<% if defined?(@rabbitmq_password) %>
+password = <%= @rabbitmq_password %>
+<% end -%>

--- a/templates/contrailctl/analyticsdb.conf.erb
+++ b/templates/contrailctl/analyticsdb.conf.erb
@@ -1,0 +1,161 @@
+[GLOBAL]
+# All global configurations which would affect multiple sections or globally
+# applicable configurations would be coming here.
+#
+
+# Default log_level
+# log_level = SYS_NOTICE
+
+# cloud_orchestrator - what cloud orchestrator is being used. Valid options:
+#  kubernetes, openstack, mesos
+<% if defined?(@cloud_orchestrator) %>
+cloud_orchestrator = <%= @cloud_orchestrator %>
+<% end -%>
+
+# hosts_entries: (OPTIONAL) a dict in form of {name1: 1.1.1.1, name2: 1.1.1.2}
+# In multi-controller systems, all hosts in the cluster should be reachable
+# using its own hostname which is requirement for rabbitmq, so for that /etc/hosts
+# entries are required, unless there is an external dns infrastructure to support it
+# Alternatively one can write /etc/hosts entries on the host before starting
+# the container, in which case container will take those entries.
+# hosts_entries = {"host1": "1.1.1.1", "host2": "1.1.1.2"}
+
+# controller_ip - An IP address using which one can connect to all public
+# services within controller container. This can be a virtual IP handled by
+# load balancer in case of multi-node controllers. This will be configured
+# in various contrail services configurations to connect to other set of
+# services like discovery_server_ip.
+# controller_ip = 127.0.0.1
+#
+# controller_nodes - Comma separated list of controller server IP
+# addresses - this will be used to configure rabbitmq, zookeeper, cassandra
+# servers in various contrail service configurations and configure
+# load balancer for variuos contrail services that needed to be loadbalanced
+# controller_nodes = 127.0.0.1
+controller_nodes = <%= @controller_nodes %>
+
+#
+# analyticsdb_nodes - Comma separated list of analyticsdb server IP addresses.
+# IP Addresses on which cassandra is supposed to listen
+# analyticsdb_nodes = 192.168.0.10
+analyticsdb_nodes = <%= @analyticsdb_nodes %>
+
+# analytics_nodes - Comma separated list of analytics server IP addresses
+# analytics_nodes = 127.0.0.1
+analytics_nodes = <%= analytics_nodes %>
+
+# analyticsdb_seed_list is to support adding new nodes to existing cluster, in
+# which case analyticsdb_seed_list is the list of existing servers in the cluster
+# and this list will be used for various clusters like cassandra
+# to join new nodes to them
+# analyticsdb_seed_list = ["12.0.0.1"]
+
+<% if defined?(@ssl_enabled) %>
+# Enable/Disable ssl for sandesh connection
+# sandesh_ssl_enable = False
+sandesh_ssl_enable = <%= @ssl_enabled %>
+
+# Enable/Disable ssl for introspect connection
+# introspect_ssl_enable = False
+introspect_ssl_enable = <%= @ssl_enabled %>
+
+xmpp_auth_enable = <%= @ssl_enabled %>
+xmpp_dns_auth_enable = <%= @ssl_enabled %>
+<% end -%>
+
+<% if defined?(@analyticsdb_cassandra_user) %>
+analyticsdb_cassandra_user = <%= @analyticsdb_cassandra_user %>
+<% end -%>
+<% if defined?(@analyticsdb_cassandra_password) %>
+analyticsdb_cassandra_password = <%= @analyticsdb_cassandra_password %>
+<% end -%>
+
+
+<% if defined?(@cloud_orchestrator) && @cloud_orchestrator == "openstack" %>
+# [KEYSTONE] - Section to get informtion about the keystone to be used by contrail,
+# Required only when orchestration is 'openstack' and keystone is managed
+# externally out of ansible.
+#
+[KEYSTONE]
+# version - Version of keystone to be used.
+# version = v2.0
+
+# ip - Ip address of the host running keystone
+# ip = 127.0.0.1
+ip = <%= @auth_host %>
+
+# admin_port - Keystone admin port in which the keystone is listening.
+# admin_port = 35357
+admin_port = <%= @admin_port %>
+
+# public_port - Keystone public port in which the keystone is listening.
+# public_port = 5000
+public_port = <%= @auth_port_public %>
+
+# auth_protocol -  Protocol used by keystone(http/https)
+# auth_protocol = http
+auth_protocol = <%= @auth_protocol %>
+
+# admin_user - Name of the admin user in keystone.
+# admin_user = admin
+admin_user = <%= @admin_user %>
+
+# admin_password - Password of the keystone admin user.
+# admin_password = admin
+admin_password = <%= @admin_password %>
+
+# admin_tenant - keystone admin tenant's name.
+# admin_tenant = admin
+admin_tenant = <%= @admin_tenant %>
+
+#insecure - Whether to validate Keystone SSL certificate.
+#insecure = False
+insecure = <%= @insecure %>
+
+<% if @auth_protocol == "https" %>
+#certfile - Keystone SSL certificate to install and use for API ports
+#certfile = /etc/contrailctl/ssl/server.pem
+<% if defined?(@certfile) && @certfile != "" %>
+certfile = <%= @certfile %>
+<% end -%>
+
+#keyfile - Keystone SSL key to use with certificate.
+#keyfile = /etc/contrailctl/ssl/server-privatekey.pem
+<% if defined?(@keyfile) && @keyfile != "" %>
+keyfile = <%= @keyfile %>
+<% end -%>
+
+#cafile - Keystone SSL CA to use with the certificate and key provided
+#Required only if using privately signed certfile and keyfile
+#cafile = /etc/contrailctl/ssl/ca-cert.pem
+<% if defined?(@cafile) && @cafile != "" %>
+cafile = <%= @cafile %>
+<% end -%>
+
+<% end -%>
+
+<% end -%>
+
+[CASSANDRA]
+# Cassandra version
+# version =  2.2
+# version_branch = 2.2
+#
+# Directory to store commitlogs. In case of any high performance disk mounted,
+# it is prefered to use that for this
+# commitlog_dir = /var/lib/cassandra/commitlog
+#
+# The directory location where table key and row caches are stored
+# saved_caches_dir = /var/lib/cassandra/saved_caches
+#
+# data_dirs - A list of directory location where table data is stored (in SSTables).
+# This is setup as list representation. Cassandra distributes data evenly across the
+# location, subject to the granularity of the configured compaction strategy.
+# data_dirs = ["/var/lib/cassandra/data"]
+#
+# listen_address - This must be an IP address - not 0.0.0.0
+# listen_address = 192.168.0.10 ; Default is first found IP address on the machine
+#
+# JAVA memory configurations
+# java_max_heap_size = 512M
+# java_max_heap_newsize = 100M

--- a/templates/contrailctl/controller.conf.erb
+++ b/templates/contrailctl/controller.conf.erb
@@ -1,0 +1,371 @@
+[GLOBAL]
+# All global configurations which would affect multiple sections or globally
+# applicable configurations would be coming here.
+#
+
+# Default log_level
+# log_level = SYS_NOTICE
+
+# cloud_orchestrator - what cloud orchestrator is being used. Valid options:
+#  kubernetes, openstack, mesos
+# cloud_orchestrator = kubernetes
+<% if defined?(@cloud_orchestrator) %>
+cloud_orchestrator = <%= @cloud_orchestrator %>
+<% end -%>
+
+# hosts_entries: (OPTIONAL) a dict in form of {name1: 1.1.1.1, name2: 1.1.1.2}
+# In multi-controller systems, all hosts in the cluster should be reachable
+# using its own hostname which is requirement for rabbitmq, so for that /etc/hosts
+# entries are required, unless there is an external dns infrastructure to support it
+# Alternatively one can write /etc/hosts entries on the host before starting
+# the container, in which case container will take those entries.
+# hosts_entries = {"host1": "1.1.1.1", "host2": "1.1.1.2"}
+
+# external_lb - Flag to identify the whether the loadbalancer is internaly
+# hosted in the lb container or managed externally.
+# Based on which the listen port of the contrail-api will be decided.
+# Default is False(Internally hosted in lb container)
+#
+# external_lb = False
+
+# controller_nodes - Comma separated list of controller server IP
+# addresses - this will be used to configure rabbitmq, zookeeper,
+# cassandra servers in various contrail service configurations and configure
+# load balancer for variuos contrail services
+# that needed to be loadbalanced
+# controller_nodes = 127.0.0.1
+controller_nodes = <%= @controller_nodes %>
+
+# controller_ip - An IP address using which one can connect to all public
+# services within controller container. This can be
+# a virtual IP handled by load balancer in case of multi-node controllers.
+# This will be configured in various contrail
+# services configurations to connect to other set of services
+# controller_ip = 127.0.0.1
+
+# config_ip - IP Address to connect config api. Usually this is same as controller_ip
+# and that is the default, but in case if you have set of controllers without configs
+# then this ip can be different.
+# config_ip =  127.0.0.1
+
+# ceph_controller_nodes - Comma seperated list of ceph controller server IP addresses - this will be used to serve ceph rest api request
+# ceph_controller_nodes = 127.0.0.1
+
+# analytics_nodes - Comma separated list of analytics server IP addresses
+# analytics_nodes = 127.0.0.1
+analytics_nodes = <%= analytics_nodes %>
+
+# external servers are those common services like zookeeper, rabbitmq, cassandra
+# which are configured and managed external to contrail cluster and given
+# to contrail services to use them. In this case those services will not be
+# deployed in contrail controller container. Instead the contrail services
+# are configured to use those external services. Also none of our code will
+# try to deploy/configure/manage any of the external services
+# external_rabbitmq_servers, external_zookeeper_servers,
+# external_cassandra_servers - Comma separated list of rabbitmq, zookeeper,
+# and cassandra respectively.
+# Example external_zookeeper_servers = 10.0.0.1,10.0.0.2
+# external_rabbitmq_servers =
+# external_zookeeper_servers =
+# external_configdb_servers =
+<% if defined?(@external_rabbitmq_servers) %>
+external_rabbitmq_servers = <%= @external_rabbitmq_servers %>
+<% end -%>
+<% if defined?(@external_zookeeper_servers) %>
+external_zookeeper_servers = <%= @external_zookeeper_servers %>
+<% end -%>
+<% if defined?(@external_configdb_servers) %>
+external_configdb_servers = <%= @external_configdb_servers %>
+<% end -%>
+<% if defined?(@external_cassandra_servers) %>
+external_cassandra_servers = <%= @external_cassandra_servers %>
+<% end -%>
+
+# config db's username password, defaultstp cassandra/cassandra
+# configdb_cassandra_user = cassandra
+# configdb_cassandra_password = cassandra
+<% if defined?(@configdb_cassandra_user) %>
+configdb_cassandra_user = <%= @configdb_cassandra_user %>
+<% end -%>
+<% if defined?(@configdb_cassandra_password) %>
+configdb_cassandra_password = <%= @configdb_cassandra_password %>
+<% end -%>
+
+
+# controller container can be running only with specific component like control
+# config or webui or combination of them enable_config_service,
+# enable_control_service, enable_webui_service will make those services enabled
+# or disabled.
+# By default all services are enabled.
+# enable_config_service = True
+# enable_control_service = True
+# enable_webui_service = True
+
+# analyticsdb_nodes - Comma separated list of analyticsdb server IP
+# addresses - this will be used to configure cassandra, and kafka servers
+# in various contrail service configurations.
+# This should be list of IP addresses where cassandra and kafka listening
+# analyticsdb_nodes = 127.0.0.1
+analyticsdb_nodes = <%= @analyticsdb_nodes %>
+
+# While making config component optional within controller container, it fails
+# the assumption that all nodes in controllers has config running and thus
+# need to set another optional entry to be configured in case config is not
+# running on all controller nodes
+# config_nodes = [""] # A list of ips that running config
+
+# config_seeds is to support adding new nodes to existing cluster, in
+# which case config_seeds is the list of existing servers in the cluster
+# and this list will be used for various clusters like rabbitmq, cassandra
+# to join new nodes to them
+# config_seeds = 12.0.0.1
+
+<% if defined?(@ssl_enabled) %>
+# Enable/Disable ssl for sandesh connection
+# sandesh_ssl_enable = False
+sandesh_ssl_enable = <%= @ssl_enabled %>
+
+# Enable/Disable ssl for introspect connection
+# introspect_ssl_enable = False
+introspect_ssl_enable = <%= @ssl_enabled %>
+
+# xmpp_auth_enable and xmpp_dns_auth_enable are two flags used to configure
+# contrail-control and contrail-dns services to use SSL certs to communicate
+# with the vrouter agent
+xmpp_auth_enable = <%= @ssl_enabled %>
+xmpp_dns_auth_enable = <%= @ssl_enabled %>
+
+<% end -%>
+
+# IP/Port for metadata server
+# neutron_metadata_ip = 1.2.3.4
+# neutron_metadata_port = 8775
+<% if defined?(@neutron_metadata_ip) %>
+neutron_metadata_ip = <%= @neutron_metadata_ip %>
+<% end -%>
+
+#
+# [CONTROLLER] section will have any global configuration for controller container
+# Any configuration here will be passed directly to contrial-ansible-internal
+# code without any changes
+#
+
+[CONTROLLER]
+# encapsulation priority. Default is MPLSoUDP,MPLSoGRE,VXLAN
+# encap_priority = MPLSoUDP,MPLSoGRE,VXLAN
+
+# external_routers_list - dictionary of external, physical routers in form of {name1: ip1, name2: ip2}
+# external_routers_list = {'r1': '192.168.0.1', 'r2': '192.168.0.2', 'r3': '192.168.0.3'}
+
+# bgp_asn - asn of control node
+# bgp_asn = 64512
+
+# flow_export_rate - flow export rate to the collector
+# flow_export_rate = 10
+
+<% if defined?(@cloud_orchestrator) && @cloud_orchestrator == "openstack" %>
+# [KEYSTONE] - Section to get informtion about the keystone to be used by contrail,
+# Required only when orchestration is 'openstack' and keystone is managed
+# externally out of ansible.
+#
+[KEYSTONE]
+# version - Version of keystone to be used.
+# version = v2.0
+
+# ip - Ip address of the host running keystone
+# ip = 127.0.0.1
+ip = <%= @auth_host %>
+
+# admin_port - Keystone admin port in which the keystone is listening.
+# admin_port = 35357
+admin_port = <%= @admin_port %>
+
+# public_port - Keystone public port in which the keystone is listening.
+# public_port = 5000
+public_port = <%= @auth_port_public %>
+
+# auth_protocol -  Protocol used by keystone(http/https)
+# auth_protocol = http
+auth_protocol = <%= @auth_protocol %>
+
+# admin_user - Name of the admin user in keystone.
+# admin_user = admin
+admin_user = <%= @admin_user %>
+
+# admin_password - Password of the keystone admin user.
+# admin_password = admin
+admin_password = <%= @admin_password %>
+
+# admin_tenant - keystone admin tenant's name.
+# admin_tenant = admin
+admin_tenant = <%= @admin_tenant %>
+
+#insecure - Whether to validate Keystone SSL certificate.
+#insecure = False
+insecure = <%= @insecure %>
+
+<% if @auth_protocol == "https" %>
+#certfile - Keystone SSL certificate to install and use for API ports
+#certfile = /etc/contrailctl/ssl/server.pem
+<% if defined?(@certfile) && @certfile != "" %>
+certfile = <%= @certfile %>
+<% end -%>
+
+#keyfile - Keystone SSL key to use with certificate.
+#keyfile = /etc/contrailctl/ssl/server-privatekey.pem
+<% if defined?(@keyfile) && @keyfile != "" %>
+keyfile = <%= @keyfile %>
+<% end -%>
+
+#cafile - Keystone SSL CA to use with the certificate and key provided
+#Required only if using privately signed certfile and keyfile
+#cafile = /etc/contrailctl/ssl/ca-cert.pem
+<% if defined?(@cafile) && @cafile != "" %>
+cafile = <%= @cafile %>
+<% end -%>
+
+<% end -%>
+
+<% end -%>
+
+[CONTROL]
+# BGP port number
+# bgp_port=179
+
+# Introspect port for debugging
+# introspect_port = 8083
+
+# xmpp server port
+# xmpp_server_port=5269
+
+# Log file and log level
+# log_file=/var/log/contrail/contrail-control.log
+# log_level=SYS_NOTICE
+
+[DNS]
+# named log file
+# named_log_file=/var/log/contrail/contrail-named.log
+
+# Introspect port for debug
+# introspect_port=8092
+
+# DNS server port
+# dns_server_port=53
+
+# Log file and log_level
+# log_file=/var/log/contrail/contrail-dns.log
+# log_level=SYS_NOTICE
+
+[CASSANDRA]
+# Directory to store commitlogs. In case of any high performance disk mounted,
+# it is prefered to use that for this
+# commitlog_dir = /var/lib/cassandra/commitlog
+#
+# The directory location where table key and row caches are stored
+# saved_caches_dir = /var/lib/cassandra/saved_caches
+#
+# data_dirs - A list of directory location where table data is stored (in SSTables).
+# This is setup as list representation. Cassandra distributes data evenly across the
+# location, subject to the granularity of the configured compaction strategy.
+# data_dirs = ["/var/lib/cassandra/data"]
+#
+# JAVA memory configurations
+# java_max_heap_size = 512M
+# java_max_heap_newsize = 100M
+
+
+[API]
+# log = /var/log/contrail/contrail-api.log
+
+# log_level = SYS_NOTICE
+
+# Enable optimizations to list resources. Be careful, resources created on
+# release under R1.05 does not support that optimization (especially for port)
+# list_optimization_enabled = True
+
+# listen_port = 8082
+# listen_address = 0.0.0.0
+
+# Authentication mode. The effects of setting this are:
+# 1. no-auth: authentictaion is disabled
+# 2. cloud-admin: Only admin is allowed access (default)
+# 3. rbac: role based access control
+
+# aaa_mode = "cloud-admin"
+<% if defined?(@aaa_mode) %>
+aaa_mode = <%= @aaa_mode %>
+<% end -%>
+
+# Other RBAC related knobs
+# cloud_admin_role = "admin"
+# global_read_only_role = None
+
+[ANALYTICS_API]
+# Authentication mode. The effects of setting this are:
+# 1. no-auth: authentictaion is disabled
+# 2. cloud-admin: Only admin is allowed access (default)
+# 3. rbac: role based access control
+
+# aaa_mode = "cloud-admin"
+<% if defined?(@analytics_aaa_mode) %>
+aaa_mode = <%= @analytics_aaa_mode %>
+<% end -%>
+
+
+[SCHEMA]
+# log = /var/log/contrail/contrail-schema.log
+
+# log_level = SYS_NOTICE
+
+[DEVICE_MANAGER]
+# log = /var/log/contrail/contrail-device-manager.log
+# log_level = SYS_NOTICE
+
+[SVC_MONITOR]
+
+# Log file and log level
+# log = /var/log/contrail/contrail-svc-monitor.log
+# log_level = SYS_NOTICE
+
+[WEBUI]
+# http_listen_port = 8080
+# https_listen_port = 8143
+# webui_storage_enable = False
+# nova_api_ip = 1.2.3.4
+<% if defined?(@nova_api_ip) %>
+nova_api_ip = <%= @nova_api_ip %>
+<% end -%>
+# glance_api_ip = 4.3.2.1
+<% if defined?(@glance_api_ip) %>
+glance_api_ip = <%= @glance_api_ip %>
+<% end -%>
+# network_manager_ip = 2.4.8.16
+# enable_underlay = False
+# enable_mx = False
+# enable_udd = False
+# service_endpoint_from_config = True
+# network_manager_auth_protocol = http
+# image_manager_auth_protocol = http
+# compute_manager_auth_protocol = http
+# server_options_key_file = /usr/src/contrail/contrail-web-core/keys/cs-key.pem
+# server_options_cert_file = /usr/src/contrail/contrail-web-core/keys/cs-cert.pem
+
+[RABBITMQ]
+# All rabbitmq releated parameters used to
+# provision rabbitmq in controller contianer
+#
+# vhost = '/'
+<% if defined?(@rabbitmq_vhost) %>
+vhost = <%= @rabbitmq_vhost %>
+<% end -%>
+# user = guest
+<% if defined?(@rabbitmq_user) %>
+user = <%= @rabbitmq_user %>
+<% end -%>
+# password = guest
+<% if defined?(@rabbitmq_password) %>
+password = <%= @rabbitmq_password %>
+<% end -%>
+#
+# owner = rabbitmq
+# group = rabbitmq


### PR DESCRIPTION
Contrail v4 support with container based deployment.

The idea of such change is to minimize number of affected modules 
In general it is not need to change any code in tripleo heat teplate and tripleo puppet,
to work with this puppet version it is enough just to follow instruction from readme with changes:
 - use this puppet-contrail version
 - put contrail containers into the same contrail rpm repo folder on undercloud node.

It is possible to:
a) instruct puppet to download all containers from another server via hiera parameter:
contrail::params::container_url:  http://some_server/some_folder 
b) use another tag for docker images than default '4.0.0.0-20’ via hiera parameter:
contrail::params::container_tag: ‘some_other _tag'
c)  tune container image names, container names and url (where to download container from) individually for config, analytics and analyticsdb via:
either
	- changing upper layers to provide parameters $container_image, $container_name, $container_url directly into the classes
		contrail::config, contrail::analytics, contrail::analyticsdatabase
		(config.pp, analytics.pp, analyticsdatabase.pp in the root manifest folder)
or
	- putting those parameters into hiera, e.g.:
	contrail::analyticsdatabase:: container_url: ‘http://someserver/folder'

it supports package based deployment for contrail version before 4 (parameter contrail::params::version).