### PR TITLE
Perform ldconfig vrouter agent for both dpdk and non-dpdk cases

### DIFF
--- a/manifests/vrouter/install.pp
+++ b/manifests/vrouter/install.pp
@@ -46,9 +46,6 @@ class contrail::vrouter::install (
     package { 'contrail-vrouter-common' :
       ensure => latest,
     }
-    exec { 'ldconfig vrouter agent':
-      command => '/sbin/ldconfig',
-    }
     exec { 'set selinux to permissive' :
       command => '/sbin/setenforce permissive',
     }
@@ -62,6 +59,9 @@ class contrail::vrouter::install (
       ensure  => file,
       source => '/usr/share/openstack-puppet/modules/contrail/files/vrouter/contrail-vrouter.rules',
     } 
+  }
+  exec { 'ldconfig vrouter agent':
+      command => '/sbin/ldconfig',
   }
   exec { '/sbin/weak-modules --add-kernel' :
     command => '/sbin/weak-modules --add-kernel',


### PR DESCRIPTION
For new build 4.0.1.0-25 it is always necessary to do for vrouter agent, not only for dpdk case.
othervise contrail-vrouter-agent fails to start because of unresolved external symbols with messages int the log /var/log/contrail/contrail-vrouter-agent-stdout.log: 
/usr/bin/contrail-vrouter-agent: error while loading shared libraries: libthriftasio.so.0: cannot open shared object file: No such file or directory